### PR TITLE
[v0.2.0] compact READMEs, move release ops into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,15 @@ fourth check) should follow the same pattern.
   Environment (required reviewer approval gate before the actual publish step runs) and
   needs `NPM_TOKEN` (npm Automation token, not a regular one — regular tokens require a
   2FA OTP that CI can't provide) and `VSCE_PAT` set as secrets on that environment.
+  One-time setup: repo Settings → Environments → New environment named `release` →
+  enable Required reviewers → add the two secrets there (not the repo-level secrets
+  page). `NPM_TOKEN` comes from npmjs.com → Access Tokens → Generate New Token →
+  Automation; `VSCE_PAT` is the same Azure DevOps PAT used for manual `vsce publish`
+  (Marketplace → Manage scope, "All accessible organizations").
+- **On a fresh clone, `npm install` runs twice**: once before the first
+  `npm run build --workspaces` (to get the toolchain), once after (so the
+  `tailwind-a11y` CLI's `node_modules/.bin` symlink gets created — it's only linked for
+  a `dist/cli.js` that already exists at install time).
 
 ## Working conventions (inherited from the engine package, apply repo-wide)
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,31 @@
 # tailwind-a11y
 
-A monorepo for a static analysis engine that resolves Tailwind CSS utility classes back
-into their real computed values (colors, sizes, focus behavior) — so WCAG accessibility
-bugs can be caught before rendering, instead of at a Lighthouse audit or QA pass after
-the fact.
+Static analysis for Tailwind CSS accessibility. Resolves utility classes into their
+real computed values — colors, sizes, focus behavior — to catch WCAG violations before
+they ship, instead of at a Lighthouse audit or QA pass.
 
 ## Packages
 
-| Package | What it is |
+| Package | Description |
 |---|---|
-| [`tailwind-a11y`](./packages/tailwind-a11y) | The engine + CLI. `npx tailwind-a11y` scans your project. |
-| [`eslint-plugin-tailwind-a11y`](./packages/eslint-plugin-tailwind-a11y) | The same checks as ESLint rules, for inline feedback during normal linting. |
-| [`vscode-tailwind-a11y`](./packages/vscode-tailwind-a11y) | The same checks as live editor diagnostics, as you type in `.jsx`/`.tsx` files. |
+| [`tailwind-a11y`](./packages/tailwind-a11y) | CLI and analysis engine |
+| [`eslint-plugin-tailwind-a11y`](./packages/eslint-plugin-tailwind-a11y) | ESLint rules |
+| [`vscode-tailwind-a11y`](./packages/vscode-tailwind-a11y) | Live editor diagnostics |
 
-All three ship the same three checks — color contrast (WCAG 1.4.3), touch target size
-(WCAG 2.5.8), and focus indicator removal (WCAG 2.4.7) — and will never disagree with
-each other, since the ESLint plugin and VS Code extension are thin adapters over the
-engine, not separate implementations. See each package's own README for install/usage
-and exact scope.
+All three run the same three checks — color contrast (WCAG 1.4.3), touch target size
+(WCAG 2.5.8), and focus indicator removal (WCAG 2.4.7) — through one shared engine, so
+results never disagree between them. See each package's README for install and usage.
 
 ## Development
 
-npm workspaces, three packages, no extra tooling (no Turborepo/Nx/Changesets — not
-warranted at this size):
-
 ```bash
-npm install                          # from repo root — installs and links both packages
-npm run build --workspaces           # builds tailwind-a11y first, then the plugin (order matters, see below)
+npm install
+npm run build --workspaces
 npm test --workspaces --if-present
 ```
 
-On a fresh clone, run `npm install` once more after the first `npm run build --workspaces`
-— the `tailwind-a11y` CLI's `node_modules/.bin` symlink is only created for a target
-(`dist/cli.js`) that already exists at install time, so the very first install predates it.
-
-**Version lockstep**: `eslint-plugin-tailwind-a11y` depends on `tailwind-a11y` via a
-plain semver range (`^0.1.0`), resolved to the local workspace as long as that range is
-satisfied by `packages/tailwind-a11y`'s actual `version`. Bumping the engine's version
-past that range without updating the plugin's dependency makes npm silently fall back to
-fetching a real package from the registry instead of using local source. After bumping
-either version, run `npm install && npm run check:link` to confirm the workspace link is
-still intact.
-
-**Adding a package**: append it to the root `package.json`'s `workspaces` array in
-dependency order — it's an explicit ordered list (not a `packages/*` glob) specifically
-so build/test scripts run engine-before-plugin; a glob would resolve alphabetically and
-build the plugin first.
-
-**Publishing**: engine first, always (`npm publish -w tailwind-a11y --access public`),
-then the plugin, only once the engine is live on the registry. The VS Code extension
-publishes separately, to the Marketplace rather than npm (`npm run package -w
-vscode-tailwind-a11y`, then `vsce publish` — see that package's README).
-
-**Automated publishing**: `.github/workflows/publish.yml` runs on every push to `main`
-(i.e. whenever a PR merges) and publishes only the package(s) whose `package.json`
-`version` field actually changed in that push — bump a version, merge, and that package
-ships on its own; unrelated commits don't touch the registry.
-
-Every publish job targets the **`release`** GitHub Environment rather than plain repo
-secrets, specifically so a **required reviewer** can be configured on it — the trigger
-is automatic, but the actual publish step pauses for manual approval first, since a
-publish (npm or Marketplace) can't be undone. Set up once, in repo Settings:
-
-1. **Settings → Environments → New environment**, name it `release`.
-2. Enable **Required reviewers** and add yourself.
-3. Add these two secrets to that environment (not the repo-level secrets page):
-   - `NPM_TOKEN` — an npm **Automation** access token (npmjs.com → Access Tokens →
-     Generate New Token → Automation). Regular tokens prompt for a 2FA one-time
-     password, which CI can't answer; Automation tokens are the sanctioned bypass.
-     Scope it to just these two packages if you want to limit blast radius from a
-     leaked token.
-   - `VSCE_PAT` — the same Azure DevOps personal access token used for manual
-     `vsce publish` (Marketplace → Manage scope, "All accessible organizations").
-
-Until the environment and secrets exist, a triggering push will sit waiting for an
-environment that doesn't exist yet — build/test steps haven't run at that point, since
-the wait-for-approval gate happens before the job's steps start.
+npm workspaces, no extra tooling. Versioning, publishing, and CI/release setup are
+documented in [CLAUDE.md](./CLAUDE.md).
 
 ## License
 

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -1,15 +1,8 @@
 # eslint-plugin-tailwind-a11y
 
-ESLint rules that catch [WCAG](https://www.w3.org/WAI/WCAG21/quickref/) accessibility
-violations in Tailwind CSS class combinations — color contrast, touch target size, and
-focus indicator removal — as part of your normal `eslint` run, instead of a separate CLI
-you have to remember to invoke.
-
-This plugin is a thin ESLint adapter over the [`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
-engine, which does the actual work: resolving Tailwind utility classes back into real
-computed values (colors, sizes) via AST analysis. Every rule here calls straight into
-that engine and reports its violations — there's no separate implementation to drift out
-of sync, and no wording that differs between `npx tailwind-a11y` and `eslint .`.
+ESLint rules for [`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y) —
+inline WCAG diagnostics during normal linting, powered by the same engine as the CLI
+and VS Code extension. No detection logic is duplicated, so results never disagree.
 
 ## Install
 
@@ -25,17 +18,12 @@ Requires ESLint 9 or 10 (flat config).
 // eslint.config.js
 import tailwindA11y from "eslint-plugin-tailwind-a11y";
 
-export default [
-  ...tailwindA11y.configs.recommended,
-];
+export default [...tailwindA11y.configs.recommended];
 ```
 
-`configs.recommended` scopes itself to `**/*.jsx`/`**/*.tsx` and enables all three rules
-as errors. To register rules manually instead:
+Or register rules individually:
 
 ```js
-import tailwindA11y from "eslint-plugin-tailwind-a11y";
-
 export default [
   {
     files: ["**/*.jsx", "**/*.tsx"],
@@ -51,48 +39,20 @@ export default [
 
 ## Rules
 
-| Rule | WCAG | Catches |
+| Rule | WCAG | Detects |
 |---|---|---|
-| `tailwind-a11y/contrast` | 1.4.3 (AA) | `text-*`/`bg-*` pairs below the 4.5:1 contrast ratio, same-element or direct-parent — reports the nearest passing shade in the same color scale when one exists |
-| `tailwind-a11y/touch-target` | 2.5.8 (AA) | Interactive elements sized under 24×24px via `w-*`/`h-*` |
-| `tailwind-a11y/focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement style |
+| `contrast` | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — suggests the nearest passing shade |
+| `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px |
+| `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
-Each rule's exact scope and known limitations are documented in the
-[engine's README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#what-it-deliberately-doesnt-catch-v1-scope) —
-this plugin doesn't change what's checked, only how it's surfaced.
+Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 
-## `.tsx` files and parsers
+## Notes
 
-The underlying engine parses each file's source independently with Babel (`jsx` +
-`typescript` plugins), so `.tsx` syntax is understood regardless of what parser your
-ESLint config uses. But ESLint itself still needs to parse the file *first* to run any
-rule at all — if your config doesn't already set a TypeScript-aware
-`languageOptions.parser` (e.g. `typescript-eslint`) for `.tsx` files, ESLint will fail to
-parse them before this plugin ever runs. If you already lint `.tsx` files today, you have
-this covered; nothing extra to add for this plugin specifically.
-
-## Relationship to the `tailwind-a11y` CLI and VS Code extension
-
-Same checks, same engine, three ways to see them: `eslint-plugin-tailwind-a11y` for
-inline, per-file feedback during normal linting; [`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
-(the CLI) for a one-shot scan, e.g. in a CI step that doesn't otherwise run ESLint; and
-the [VS Code extension](https://github.com/chamroro/tailwind-a11y/tree/main/packages/vscode-tailwind-a11y)
-for live squiggly-underline feedback as you type. Use any combination — they'll never
-disagree, since none of them reimplement detection logic.
-
-## Development
-
-This package lives in the [`tailwind-a11y` monorepo](https://github.com/chamroro/tailwind-a11y)
-(npm workspaces) alongside the engine it depends on:
-
-```bash
-npm install                              # from the monorepo root
-npm run build --workspaces               # or: npm run build -w tailwind-a11y -w eslint-plugin-tailwind-a11y
-npm test --workspaces --if-present
-```
-
-After changing the engine (`packages/tailwind-a11y`), rebuild it before running this
-package's tests — the workspace dependency resolves through its `dist/`, not its `src/`.
+`.tsx` files need a TypeScript-aware `languageOptions.parser` (e.g. `typescript-eslint`)
+in your own config for ESLint to parse them at all. This plugin's own analysis
+understands TypeScript syntax regardless — but ESLint has to parse the file successfully
+before any rule, including this one, ever runs.
 
 ## License
 

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -1,55 +1,17 @@
 # tailwind-a11y
 
-A static analysis engine that resolves Tailwind CSS utility classes back into their real
-computed values (colors, sizes, focus behavior) via AST parsing — so accessibility bugs
-can be caught **before rendering**, in CI, instead of at a Lighthouse audit or QA pass
-after the fact. Three [WCAG](https://www.w3.org/WAI/WCAG21/quickref/) checks ship on top
-of that engine today: color contrast, touch target size, and focus indicator removal.
+CLI that catches WCAG accessibility violations in Tailwind CSS class combinations
+before they ship.
 
-> Renamed from `tailwind-contrast-guard` once these three checks landed. This package now
-> lives in the [`tailwind-a11y` monorepo](https://github.com/chamroro/tailwind-a11y)
-> alongside its [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
-> and [VS Code extension](https://github.com/chamroro/tailwind-a11y/tree/main/packages/vscode-tailwind-a11y) —
-> same engine, three ways to see the results.
-
-## The actual problem this solves
-
-The pain isn't "checking contrast" — plenty of tools do that. The pain is finding out
-about an accessibility bug **late**: at a design review, an axe/Lighthouse audit, or a
-QA pass, days or weeks after the code that caused it was written and merged. By the time
-that class combination surfaces as one of forty findings on a spreadsheet, nobody
-remembers why `text-gray-400` ended up on that element.
-
-`tailwind-a11y` moves that feedback to write-time by actually understanding what a
-Tailwind class *renders as* — not just matching class names, but resolving `text-gray-400`
-to `#9ca3af`, `w-4` to `16px`, and evaluating those against the real WCAG formulas. That's
-what makes it different from a linter that only knows class *names* exist:
+Resolves Tailwind utility classes into their real computed values via AST analysis,
+rather than matching class names. This catches a pattern most contrast checkers miss —
+background color on a parent element, text color on a child:
 
 ```jsx
 <div className="bg-white">
-  <p className="text-gray-400">the background is on the parent, not this element</p>
+  <p className="text-gray-400">not caught by most tools — but fails WCAG AA</p>
 </div>
 ```
-
-Most existing Tailwind contrast checkers only catch `text-*`/`bg-*` on the **same**
-element and miss this — extremely common — direct-parent pattern entirely, because they
-never resolve the parent's class at all.
-
-## What's built on the engine today
-
-```jsx
-<button className="w-4 h-4" onClick={...}>×</button>          {/* 16×16px, fails WCAG 2.5.8 */}
-<button className="focus:outline-none">Save</button>          {/* no visible focus indicator */}
-```
-
-- **Contrast** (WCAG 1.4.3) — same-element and direct-parent `text-*`/`bg-*` combinations
-- **Touch target size** (WCAG 2.5.8) — interactive elements under 24×24px
-- **Focus indicator removal** (WCAG 2.4.7) — `focus:outline-none` with no visible replacement
-
-These three exist because they're the checks a Tailwind-aware engine can answer with high
-confidence today. The engine itself — turning a utility class into a real value — isn't
-specific to accessibility; it's the reusable part, and more checks can sit on top of it
-without becoming a different tool.
 
 ## Install
 
@@ -60,80 +22,47 @@ npm install --save-dev tailwind-a11y
 ## Usage
 
 ```bash
-npx tailwind-a11y                    # scans **/*.{jsx,tsx} from the current directory
-npx tailwind-a11y "src/**/*.tsx"     # or pass your own glob pattern(s)
+npx tailwind-a11y                    # scans **/*.{jsx,tsx}
+npx tailwind-a11y "src/**/*.tsx"     # custom glob
 npx tailwind-a11y --verbose          # also reports what couldn't be checked, and why
 ```
-
-`--verbose` surfaces the coverage gap explicitly instead of leaving it invisible — e.g. a
-custom theme color that can't be resolved, or a background set inside a wrapping
-component this tool can't see into. A skip is not a pass; it means "not checked."
-
-Example output:
 
 ```
 src/components/Card.tsx
   3: text-gray-400 on bg-white — ratio 2.54, needs 4.5 (AA); try text-gray-500 (4.83)
 src/components/IconButton.tsx
   5: <button> is 16×16px (w-4 h-4) — WCAG 2.5.8 requires >= 24×24px
-  12: <button> removes the focus outline (focus:outline-none) with no visible replacement
 
-3 issue(s) in 2 file(s)
+2 issue(s) in 2 file(s)
 ```
 
-Exits with code `1` when issues are found, `0` otherwise — drop it into CI:
+Exits `1` on violations — safe to use as a CI gate.
 
-```yaml
-# .github/workflows/a11y.yml
-- run: npx tailwind-a11y
-```
+## Checks
 
-## What it catches
+| Check | WCAG | Detects |
+|---|---|---|
+| Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent; suggests the nearest passing shade |
+| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px |
+| Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
-- **Contrast** (WCAG 1.4.3): `text-*`/`bg-*` on the **same element**, or `text-*` on a
-  child with `bg-*` on its **immediate JSX parent** (one level up, exactly). Tailwind's
-  default color palette, plus arbitrary hex values (`text-[#123456]`).
-- **Touch target size** (WCAG 2.5.8): interactive elements (`button`, `a`, `input`,
-  `select`, `textarea`, or any element with an `onClick` handler) sized below 24×24px via
-  explicit `w-*`/`h-*` utilities.
-- **Focus indicator removal** (WCAG 2.4.7): `focus:outline-none`/`focus-visible:outline-none`
-  with no other `focus:`/`focus-visible:` utility (`ring-*`, `border-*`, `shadow-*`, `bg-*`,
-  non-`none` `outline-*`) providing a visible replacement.
-- All checks: static `className="..."` string literals only.
+## Scope
 
-## What it deliberately doesn't catch (v1 scope)
+When a case can't be resolved with confidence, it's skipped rather than guessed:
 
-These are intentional limitations, not bugs — each would require a fundamentally heavier
-tool (whole-program or runtime analysis) for a comparatively rare payoff. When a check can't
-be resolved with confidence, it is **skipped, not guessed** — a wrong "pass" is worse than
-no answer:
+- Ancestors beyond the immediate parent, or backgrounds set inside a separate component
+- Dynamic or computed `className` (ternaries, `clsx()`, template literals)
+- Custom theme colors/spacing not in Tailwind's default scales
+- Color + opacity shorthand (`bg-white/50`)
+- Frameworks other than React/JSX
 
-- **Ancestors beyond the immediate parent**, or backgrounds set inside a separately-defined
-  wrapping component (e.g. `<Card><Text/></Card>` where `Card` sets `bg-white` internally).
-  This is the most common source of missed violations in real component-library-heavy
-  codebases (MUI, Chakra, shadcn/ui, Radix) — resolving it would require whole-program,
-  type-aware analysis across file boundaries, a different tool than this.
-- **Dynamic or computed `className`** — ternaries, template literals, `clsx()`/`cva()`
-  composition. These are silently skipped, never guessed at.
-- **Custom theme colors/spacing** not in Tailwind's default scales (e.g. `text-brand-500`)
-- **Color + opacity shorthand** (`bg-white/50`) — skipped rather than alpha-composited,
-  since a wrong guess is worse than no answer
-- **Large-text contrast thresholds** (3.0:1 instead of 4.5:1) — every check currently uses
-  the normal-text AA threshold
-- **`min-w-*`/`min-h-*` sizing**, and WCAG 2.5.8's inline-text-link exception — touch target
-  checks require explicit `w-*`+`h-*`, no fallback/exception heuristics in v1
-- Frameworks other than React/JSX (Vue, Svelte, Blade, …)
+`--verbose` reports what was skipped and why — a skip is not a pass. Full rationale in
+[CLAUDE.md](./CLAUDE.md).
 
-See [CLAUDE.md](./CLAUDE.md) for the full rationale behind these boundaries.
+## Related
 
-## Development
-
-```bash
-npm install
-npm run dev -- "src/**/*.tsx"   # run the CLI against a project without building
-npm test                        # vitest
-npm run build                   # tsc -> dist/
-```
+- [`eslint-plugin-tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y) — same checks as ESLint rules
+- [`vscode-tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/vscode-tailwind-a11y) — same checks as live editor diagnostics
 
 ## License
 

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -1,62 +1,23 @@
-# vscode-tailwind-a11y
+# Tailwind a11y
 
-Inline [WCAG](https://www.w3.org/WAI/WCAG21/quickref/) diagnostics for Tailwind CSS class
-combinations, right in the editor — color contrast, touch target size, and focus indicator
-removal, as you type in `.jsx`/`.tsx` files.
+Live WCAG diagnostics for Tailwind CSS, in the editor — the same three checks as
+[`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
+and its [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y),
+powered by the same engine. Results never disagree between them — no detection logic is
+reimplemented here.
 
-This extension is a thin adapter over the [`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
-engine — the same one the CLI and [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
-use. No detection logic is reimplemented here, so the squiggly underline you see in the
-editor will never disagree with what `npx tailwind-a11y` or `eslint` report for the same
-code.
+## What it shows
 
-## What it catches
+| Check | WCAG | Detects |
+|---|---|---|
+| Contrast | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — with a suggested nearby shade |
+| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px |
+| Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
-- **Contrast** (WCAG 1.4.3) — including a suggested nearby shade that would pass, when one
-  exists in the same color scale, e.g. `text-gray-400 on bg-white — ratio 2.54, needs 4.5
-  (AA); try text-gray-500 (4.83)`
-- **Touch target size** (WCAG 2.5.8) — interactive elements under 24×24px
-- **Focus indicator removal** (WCAG 2.4.7) — `focus:outline-none` with no visible replacement
-
-Diagnostics show as warnings (not errors) — a squiggly underline in an editor reads as a
-compile failure otherwise. For CI gating, use the CLI or ESLint plugin instead, which treat
-the same findings as errors.
-
-Re-analysis runs on file open, file save, and (debounced ~300ms) as you type. Each
-finding's exact scope and known limitations are documented in the
-[engine's README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#what-it-deliberately-doesnt-catch-v1-scope).
-
-## Development
-
-This package lives in the [`tailwind-a11y` monorepo](https://github.com/chamroro/tailwind-a11y)
-(npm workspaces):
-
-```bash
-npm install                          # from the monorepo root
-npm run build -w tailwind-a11y       # engine must be built first — this extension
-                                      # bundles its dist/, not its src/
-npm run build -w vscode-tailwind-a11y
-```
-
-Then press F5 in VS Code (with this package open) to launch an Extension Development Host
-and try it against a `.tsx` file.
-
-### Packaging
-
-This extension **must** be bundled (esbuild) rather than shipped as raw compiled output —
-in this monorepo, `vsce`'s dependency collector only looks inside this package's own
-directory, and npm workspaces hoists all dependencies (including `tailwind-a11y` itself) to
-the monorepo root. An unbundled build would produce a `.vsix` with broken paths.
-
-```bash
-npm run package -w vscode-tailwind-a11y   # vsce package --no-dependencies
-```
-
-### Publishing
-
-Requires a [Visual Studio Marketplace publisher](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher)
-identity and an Azure DevOps personal access token — both manual, account-bound setup
-steps, not part of this repo. Set `publisher` in `package.json` before packaging for real.
+Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
+(debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
+or [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
+instead — both treat the same findings as errors.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrites all four READMEs (root + 3 packages) to be shorter and more focused on
  install/usage — trims narrative backstory and per-package "Development" sections
  that were really maintainer notes, not user-facing docs.
- Moves CI/release setup (NPM_TOKEN, VSCE_PAT, the required-reviewer `release`
  environment) entirely into CLAUDE.md — operational detail for whoever maintains
  releases, not something an npm/Marketplace consumer needs to see.

## Context
The 0.2.0 feature work (contrast auto-fix suggestions, the VS Code extension adapter,
and the auto-publish GitHub Action) already landed on `main` in earlier commits. This
PR only touches documentation — no `package.json` versions change, so merging this
will not trigger the publish workflow.

## Test plan
- [x] Verified no broken markdown links after the rewrite (`grep` for stale anchors)
- [x] Confirmed this diff touches no `packages/*/package.json` files (publish workflow
      trigger stays dormant on merge)