### PR TITLE
[V0.3.0] Add CLI --version/--help flags, sync all packages to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6643,10 +6643,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.2.0"
+        "tailwind-a11y": "^0.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6662,7 +6662,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6685,10 +6685,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.1.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.2.0"
+        "tailwind-a11y": "^0.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.2.0"
+    "tailwind-a11y": "^0.3.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,6 +25,8 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                    # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"     # custom glob
 npx tailwind-a11y --verbose          # also reports what couldn't be checked, and why
+npx tailwind-a11y --version          # print the installed version
+npx tailwind-a11y --help             # usage and all options
 ```
 
 ```

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { relative, sep } from "node:path";
+import { createRequire } from "node:module";
 import fg from "fast-glob";
 import { extractChecks, extractContrastSkips } from "./parser/extractClasses.js";
 import { checkContrast, checkContrastValueSkips, type ContrastViolation } from "./rules/checkContrast.js";
@@ -8,6 +9,11 @@ import { extractTouchTargetChecks, extractTouchTargetSkips } from "./parser/extr
 import { checkTouchTargets, type TouchTargetViolation } from "./rules/checkTouchTarget.js";
 import { extractFocusIndicatorChecks } from "./parser/extractFocusIndicators.js";
 import { checkFocusIndicators, type FocusIndicatorViolation } from "./rules/checkFocusIndicator.js";
+import { parseArgs, getHelpText } from "./cliArgs.js";
+
+// ../package.json resolves correctly from both src/ (dev) and dist/ (published).
+const require = createRequire(import.meta.url);
+const { version: packageVersion } = require("../package.json") as { version: string };
 
 type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation;
 
@@ -44,9 +50,17 @@ function groupByFile<T extends { file: string }>(items: T[]): Map<string, T[]> {
 }
 
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const verbose = args.includes("--verbose") || args.includes("-v");
-  const patterns = args.filter((a) => a !== "--verbose" && a !== "-v");
+  const { help, version, verbose, patterns } = parseArgs(process.argv.slice(2));
+
+  if (help) {
+    console.log(getHelpText());
+    return;
+  }
+  if (version) {
+    console.log(packageVersion);
+    return;
+  }
+
   const globPatterns = patterns.length > 0 ? patterns : ["**/*.{jsx,tsx}"];
 
   const files = await fg(globPatterns, {

--- a/packages/tailwind-a11y/src/cliArgs.test.ts
+++ b/packages/tailwind-a11y/src/cliArgs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs, getHelpText } from "./cliArgs.js";
+
+describe("parseArgs", () => {
+  it("defaults to no flags and no patterns", () => {
+    expect(parseArgs([])).toEqual({ help: false, version: false, verbose: false, patterns: [] });
+  });
+
+  it("recognizes --verbose and its short form -v", () => {
+    expect(parseArgs(["--verbose"]).verbose).toBe(true);
+    expect(parseArgs(["-v"]).verbose).toBe(true);
+  });
+
+  it("recognizes --version and its short form -V (uppercase, distinct from -v)", () => {
+    expect(parseArgs(["--version"]).version).toBe(true);
+    expect(parseArgs(["-V"]).version).toBe(true);
+    expect(parseArgs(["-v"]).version).toBe(false);
+  });
+
+  it("recognizes --help and its short form -h", () => {
+    expect(parseArgs(["--help"]).help).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+
+  it("treats any non-flag argument as a glob pattern", () => {
+    expect(parseArgs(["src/**/*.tsx"]).patterns).toEqual(["src/**/*.tsx"]);
+  });
+
+  it("separates flags from patterns when mixed", () => {
+    const result = parseArgs(["--verbose", "src/**/*.tsx", "app/**/*.jsx"]);
+    expect(result.verbose).toBe(true);
+    expect(result.patterns).toEqual(["src/**/*.tsx", "app/**/*.jsx"]);
+  });
+});
+
+describe("getHelpText", () => {
+  it("documents all three flags", () => {
+    const text = getHelpText();
+    expect(text).toContain("--verbose");
+    expect(text).toContain("--version");
+    expect(text).toContain("--help");
+  });
+});

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -1,0 +1,42 @@
+// Split out from cli.ts so it's importable in tests without triggering
+// cli.ts's top-level main() call (which does real file I/O on import).
+
+export interface ParsedArgs {
+  help: boolean;
+  version: boolean;
+  verbose: boolean;
+  patterns: string[];
+}
+
+const HELP_TEXT = `Usage: tailwind-a11y [options] [<glob>...]
+
+Static analysis for Tailwind CSS accessibility violations -- color contrast,
+touch target size, and focus indicator removal.
+
+Options:
+  -v, --verbose   Also report what couldn't be checked, and why
+  -V, --version   Print the version number
+  -h, --help      Print this help message
+
+Examples:
+  tailwind-a11y                    Scan **/*.{jsx,tsx} from the current directory
+  tailwind-a11y "src/**/*.tsx"     Scan a custom glob pattern
+  tailwind-a11y --verbose          Also report skipped/unresolvable cases
+`;
+
+export function getHelpText(): string {
+  return HELP_TEXT;
+}
+
+// -v/--verbose already existed before --version was added; -V (uppercase)
+// avoids colliding with it, matching a common CLI convention.
+const FLAGS = new Set(["--verbose", "-v", "--version", "-V", "--help", "-h"]);
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  return {
+    help: argv.includes("--help") || argv.includes("-h"),
+    version: argv.includes("--version") || argv.includes("-V"),
+    verbose: argv.includes("--verbose") || argv.includes("-v"),
+    patterns: argv.filter((a) => !FLAGS.has(a)),
+  };
+}

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -48,7 +48,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.2.0"
+    "tailwind-a11y": "^0.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Adds `--version`/`-V` and `--help`/`-h` flags to the `tailwind-a11y` CLI
  (`-V` uppercase to avoid colliding with the existing `-v` short form for `--verbose`)
- Syncs `tailwind-a11y`, `eslint-plugin-tailwind-a11y`, and `vscode-tailwind-a11y` to
  `0.3.0` together, with dependency ranges updated to match

## Test plan
- [x] 121 tests pass across all three packages (105 + 12 + 4)
- [x] `npm run check:link` confirms all three resolve to the local workspace, not the registry
- [x] Manual smoke test: `--version`, `-V`, `--help`, and `-v` (still verbose, not version) all behave correctly
- [ ] First real end-to-end test of the automated publish workflow (`.github/workflows/publish.yml`) — merging this should trigger all three publish jobs