### PR TITLE
Add WCAG 2.5.8 inline-text-link exception to touch-target check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,14 @@ fourth check) should follow the same pattern.
   `tailwind-a11y` itself) to the monorepo root, so an unbundled build produces a
   `.vsix` with broken `../..` paths or missing deps. A raw `tsc` build here is broken,
   not just non-optimal.
+- **A fix to the engine's detection logic requires bumping `vscode-tailwind-a11y`'s own
+  version too, even when its source didn't change.** `eslint-plugin-tailwind-a11y`
+  resolves `tailwind-a11y` dynamically from `node_modules` at each consumer's install,
+  so a new engine patch reaches it automatically without a plugin republish. But because
+  `vscode-tailwind-a11y` bundles the engine into a static `.vsix` at build time, there is
+  no dependency resolution happening on the end user's machine — a bug fix to the engine
+  is frozen out of every Marketplace install until the extension itself is rebuilt and
+  republished with a bumped version.
 - **`.github/workflows/publish.yml` auto-publishes on push to `main`, gated per-package
   by whether that package's `version` field actually changed in the push.** A version
   bump landing via a merged PR is what triggers a real publish — don't bump a version

--- a/package-lock.json
+++ b/package-lock.json
@@ -6662,7 +6662,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6685,7 +6685,7 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "tailwind-a11y": "^0.3.0"

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -55,8 +55,16 @@ Tailwind-class-level sizing or focus-style analysis).
 - **Touch target: no `min-w-*`/`min-h-*` fallback.** A minimum-width utility
   only guarantees a floor, not the actual rendered size — using it would
   mean guessing, so elements without explicit `w-*`+`h-*` are skipped
-  entirely rather than approximated. No inline-text-link exception either
-  (WCAG 2.5.8 exempts links within a text block) — v1 simplicity.
+  entirely rather than approximated. The WCAG 2.5.8 "Inline" exception
+  (targets inside a sentence/text block are exempt) *is* implemented — see
+  `isInlineInText()` in `parser/extractTouchTargets.ts`. It only recognizes
+  a literal `JSXText` sibling immediately before/after the target — text
+  delivered via `{"..."}` or a conditionally-rendered wrapper isn't detected,
+  so those inline links are still (conservatively) flagged. Under-exempting
+  is the safe direction here; the reverse — over-exempting based on text
+  anywhere in the parent rather than adjacent to the target — was caught in
+  review as the same shape-not-meaning failure class noted below, just at
+  the sibling level instead of the token level.
 - **Focus indicator: `focus:` and `focus-visible:` are merged** for the
   removal-vs-replacement comparison, since the standard accessible pattern
   (`focus:outline-none focus-visible:ring-2`) spans both variants.

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractTouchTargets.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractTouchTargets.test.ts
@@ -61,6 +61,36 @@ describe("extractTouchTargetChecks", () => {
     const code = `const C = () => <div className="w-4 h-4">x</div>;`;
     expect(extractTouchTargetChecks(code, "fake.tsx")).toEqual([]);
   });
+
+  it("does not flag a link inline within a sentence (WCAG 2.5.8 inline exception)", () => {
+    const code = `const C = () => <p>Click <a href="#" className="w-4 h-4">here</a> to continue.</p>;`;
+    expect(extractTouchTargetChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("still flags a target whose only text siblings are JSX formatting whitespace (regression)", () => {
+    const code = `
+      const C = () => (
+        <div>
+          <a href="#" className="w-4 h-4">x</a>
+        </div>
+      );
+    `;
+    expect(extractTouchTargetChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("still flags a target whose parent has no text at all", () => {
+    const code = `const C = () => <div className="flex"><a href="#" className="w-4 h-4">x</a></div>;`;
+    expect(extractTouchTargetChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("does not let one sibling's adjacent text blanket-exempt a sibling that isn't itself adjacent to it (regression)", () => {
+    // Only the first button sits next to "Choose: "; the second sits between
+    // two buttons and should still be flagged. A parent-wide "does this
+    // element's parent contain text anywhere" check would wrongly exempt
+    // both.
+    const code = `const C = () => <p>Choose: <button className="w-4 h-4">A</button><button className="w-4 h-4">B</button></p>;`;
+    expect(extractTouchTargetChecks(code, "fake.tsx")).toHaveLength(1);
+  });
 });
 
 describe("extractTouchTargetSkips", () => {

--- a/packages/tailwind-a11y/src/parser/extractTouchTargets.ts
+++ b/packages/tailwind-a11y/src/parser/extractTouchTargets.ts
@@ -1,4 +1,5 @@
 import * as t from "@babel/types";
+import type { NodePath } from "@babel/traverse";
 import { getStaticClassName, parseJSX, traverse } from "./babelInterop.js";
 import { isInteractiveElement } from "./isInteractiveElement.js";
 import { spacingScale } from "../theme/spacingScale.js";
@@ -32,6 +33,31 @@ function lastSizeToken(tokens: string[], prefix: "w" | "h"): SizeToken | null {
   return found;
 }
 
+function isMeaningfulText(node: t.Node | undefined): boolean {
+  // Pure JSX-formatting whitespace (indentation/newlines between elements)
+  // doesn't count as text.
+  return !!node && t.isJSXText(node) && node.value.trim().length > 0;
+}
+
+// WCAG 2.5.8's "Inline" exception: a target inside a sentence or block of
+// text is exempt from the minimum size, since its size is constrained by
+// surrounding text flow rather than a deliberate layout choice. Checked via
+// the element's *immediate* siblings only (not "any text anywhere in the
+// parent") — a parent-wide check would exempt every sibling in something
+// like `<p>Choose: <button/><button/></p>` just because the first button
+// happens to sit next to text, even though the second one doesn't. That's
+// the same "shape, not meaning" failure mode as the bg-opacity-50/ring-0
+// false negatives documented in CLAUDE.md, just at the sibling level instead
+// of the token level.
+function isInlineInText(path: NodePath<t.JSXElement>): boolean {
+  const parentNode = path.parentPath?.node;
+  if (!parentNode || (!t.isJSXElement(parentNode) && !t.isJSXFragment(parentNode))) return false;
+  const siblings = parentNode.children;
+  const index = siblings.indexOf(path.node);
+  if (index === -1) return false;
+  return isMeaningfulText(siblings[index - 1]) || isMeaningfulText(siblings[index + 1]);
+}
+
 export function extractTouchTargetChecks(code: string, filePath: string): TouchTargetCheck[] {
   const ast = parseJSX(code, filePath);
   if (!ast) return [];
@@ -54,6 +80,8 @@ export function extractTouchTargetChecks(code: string, filePath: string): TouchT
       const widthPx = spacingScale[width.value];
       const heightPx = spacingScale[height.value];
       if (widthPx === undefined || heightPx === undefined) return; // arbitrary/keyword/fraction — skip
+
+      if (isInlineInText(path)) return; // WCAG 2.5.8 inline exception — exempt, not a violation
 
       checks.push({
         file: filePath,

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",


### PR DESCRIPTION
## Summary
- Implements WCAG 2.5.8's "Inline" exception in the touch-target check: an interactive element immediately adjacent to real text (not JSX-formatting whitespace) is now exempt from the 24×24px minimum, since its size is constrained by surrounding text flow rather than a deliberate layout choice.
- Caught and fixed a false negative in independent review: the first implementation checked "does the parent contain non-whitespace text *anywhere*", which would have blanket-exempted every sibling in a row of buttons even if only one actually sat next to text. Fixed to check adjacency (immediate previous/next sibling) instead — the same shape-not-meaning failure class as the project's past `bg-opacity-50`/`ring-offset-2` false negatives, just at the sibling level instead of the token level.
- Known scope limit: only a literal `JSXText` sibling is recognized. Text delivered via `{"..."}` or a conditionally-rendered wrapper isn't detected, so those cases are still (conservatively) flagged rather than guessed at.

## Versions
- `tailwind-a11y`: `0.3.0` → `0.3.1` (patch — reduces false positives, doesn't turn any previously-passing case into a failure)
- `vscode-tailwind-a11y`: `0.3.0` → `0.3.1` (own source unchanged, but it bundles the engine into a static `.vsix` at build time — needs its own version bump to actually ship the fix to the Marketplace)
- `eslint-plugin-tailwind-a11y`: unchanged (resolves the engine dynamically via `node_modules`, so it picks up the fix automatically on the next install/update)