### PR TITLE
Add custom Tailwind theme support (theme.extend.colors/spacing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6643,10 +6643,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.3.0"
+        "tailwind-a11y": "^0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6662,7 +6662,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6685,10 +6685,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.3.0"
+        "tailwind-a11y": "^0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -47,6 +47,18 @@ export default [
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 
+## Custom theme
+
+A `tailwind.config.js`/`.cjs` in ESLint's cwd is auto-detected; point at a specific
+file instead via `settings`:
+
+```js
+export default [
+  ...tailwindA11y.configs.recommended,
+  { settings: { "tailwind-a11y": { configPath: "./tailwind.config.cjs" } } },
+];
+```
+
 ## Notes
 
 `.tsx` files need a TypeScript-aware `languageOptions.parser` (e.g. `typescript-eslint`)

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.3.0"
+    "tailwind-a11y": "^0.4.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/contrast.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/contrast.test.ts
@@ -1,10 +1,22 @@
 import { RuleTester } from "eslint";
-import { describe, it } from "vitest";
+import { afterAll, describe, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import rule from "./contrast.js";
 
 RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "eslint-plugin-tailwind-a11y-"));
+const customConfigPath = join(fixtureDir, "tailwind.config.js");
+writeFileSync(
+  customConfigPath,
+  `module.exports = { theme: { extend: { colors: { brand: { 500: "#9ca3af" } } } } };` // same hex as gray-400
+);
+
+afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -26,8 +38,26 @@ ruleTester.run("contrast", rule, {
       filename: "Dynamic.jsx",
       code: `export const D = ({ c }) => <p className={c}>hi</p>;`,
     },
+    {
+      name: "a custom-theme color is silently skipped with no configured theme",
+      filename: "Brand.jsx",
+      code: `export const Ok = () => <p className="text-brand-500 bg-white">hi</p>;`,
+    },
   ],
   invalid: [
+    {
+      name: 'resolves a custom-theme color via settings["tailwind-a11y"].configPath',
+      filename: "Brand.jsx",
+      code: `export const Ok = () => <p className="text-brand-500 bg-white">hi</p>;`,
+      settings: { "tailwind-a11y": { configPath: customConfigPath } },
+      errors: [
+        {
+          message: "text-brand-500 on bg-white — ratio 2.54, needs 4.5 (AA)",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
     {
       name: "background inherited from the direct parent",
       filename: "Card.jsx",

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/contrast.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/contrast.ts
@@ -1,5 +1,6 @@
 import type { Rule } from "eslint";
 import { extractChecks, checkContrast } from "tailwind-a11y";
+import { resolveThemeForContext } from "../theme.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -27,7 +28,8 @@ const rule: Rule.RuleModule = {
       // parse of the raw source, so this never participates in ESLint's
       // own AST traversal.
       Program() {
-        const violations = checkContrast(extractChecks(context.sourceCode.getText(), context.filename));
+        const { palette } = resolveThemeForContext(context);
+        const violations = checkContrast(extractChecks(context.sourceCode.getText(), context.filename), palette);
 
         for (const v of violations) {
           const data: Record<string, string | number> = {

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.test.ts
@@ -1,10 +1,19 @@
 import { RuleTester } from "eslint";
-import { describe, it } from "vitest";
+import { afterAll, describe, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import rule from "./touch-target.js";
 
 RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "eslint-plugin-tailwind-a11y-"));
+const customConfigPath = join(fixtureDir, "tailwind.config.js");
+writeFileSync(customConfigPath, `module.exports = { theme: { extend: { spacing: { "5.5": "1.375rem" } } } };`); // 22px
+
+afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -26,8 +35,26 @@ ruleTester.run("touch-target", rule, {
       filename: "NotInteractive.jsx",
       code: `export const D = () => <div className="w-4 h-4">x</div>;`,
     },
+    {
+      name: "a custom spacing token is silently skipped with no configured theme",
+      filename: "Small.jsx",
+      code: `export const Small = () => <button className="w-5.5 h-5.5" onClick={() => {}}>x</button>;`,
+    },
   ],
   invalid: [
+    {
+      name: 'resolves a custom spacing token via settings["tailwind-a11y"].configPath',
+      filename: "Small.jsx",
+      code: `export const Small = () => <button className="w-5.5 h-5.5" onClick={() => {}}>x</button>;`,
+      settings: { "tailwind-a11y": { configPath: customConfigPath } },
+      errors: [
+        {
+          message: "<button> is 22×22px (w-5.5 h-5.5) — WCAG 2.5.8 requires >= 24×24px",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
     {
       name: "16x16 icon button fails",
       filename: "IconButton.jsx",

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.ts
@@ -1,5 +1,6 @@
 import type { Rule } from "eslint";
 import { extractTouchTargetChecks, checkTouchTargets } from "tailwind-a11y";
+import { resolveThemeForContext } from "../theme.js";
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -20,7 +21,10 @@ const rule: Rule.RuleModule = {
   create(context) {
     return {
       Program() {
-        const violations = checkTouchTargets(extractTouchTargetChecks(context.sourceCode.getText(), context.filename));
+        const { spacing } = resolveThemeForContext(context);
+        const violations = checkTouchTargets(
+          extractTouchTargetChecks(context.sourceCode.getText(), context.filename, spacing)
+        );
 
         for (const v of violations) {
           context.report({

--- a/packages/eslint-plugin-tailwind-a11y/src/theme.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/theme.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+import type { Rule } from "eslint";
+import { resolveTheme, type ResolvedTheme } from "tailwind-a11y";
+
+interface TailwindA11ySettings {
+  configPath?: string;
+}
+
+// Reads an optional override from ESLint's shared `settings` object rather
+// than rule `options`: every rule's `meta.schema` is `[]`, so an `options`
+// object would be hard-rejected by ESLint before the rule ever runs, while
+// `settings` isn't schema-validated. Falls back to auto-detecting
+// tailwind.config.js/.cjs in `context.cwd` when no override is given.
+export function resolveThemeForContext(context: Rule.RuleContext): ResolvedTheme {
+  const settings = context.settings["tailwind-a11y"] as TailwindA11ySettings | undefined;
+  const configPath = settings?.configPath ? resolve(context.cwd, settings.configPath) : null;
+  return resolveTheme({ rootDir: context.cwd, configPath });
+}

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -47,11 +47,32 @@ Tailwind-class-level sizing or focus-style analysis).
   `packages/vscode-tailwind-a11y` now exists as a third adapter over this
   engine (alongside the ESLint plugin) — it does not change this package's
   own scope, it just reuses `extractChecks`/`checkContrast` etc. directly.
-- **Default Tailwind palette only.** Color resolution uses a hardcoded
-  snapshot of Tailwind's default color scale (see `src/theme/defaultPalette.ts`).
-  Custom theme extension (reading a user's `tailwind.config`) is deferred.
-- **Default Tailwind spacing scale only.** Same reasoning as the color
-  palette — see `src/theme/spacingScale.ts`.
+- **Custom `tailwind.config.js`/`.cjs` theme extension *is* implemented** (see
+  `theme/loadCustomTheme.ts`), but narrowly:
+  - Reads only `theme.extend.colors`/`theme.extend.spacing` — never a full
+    `theme.colors`/`theme.spacing` replacement.
+  - `.js`/`.cjs` only. No `.mjs`/`.ts` config files (no config-transpiling
+    dependency exists in this package, and none is being added just for
+    this). A `.js` config inside a `"type": "module"` project throws
+    `ERR_REQUIRE_ESM` on `require()` — caught, treated the same as "no
+    config found," not a crash.
+  - Tailwind v4's CSS-first `@theme` config is not read at all.
+  - No ancestor-directory search — only the given root dir is checked.
+    `--config` (CLI) / `settings["tailwind-a11y"].configPath` (ESLint) exist
+    as explicit overrides.
+  - Per color entry: only a plain object of hex-string shades is accepted
+    (validated with the existing `hexToRgb`). A flat string color
+    (`colors: { brand: '#3490dc' }`) or a `DEFAULT` key is skipped — no
+    class syntax (`bg-brand-DEFAULT` isn't real Tailwind) would ever resolve
+    to it.
+  - Per spacing entry: only `rem`/`px` string values are accepted (rem × 16,
+    matching `spacingScale.ts`'s own 16px-root assumption).
+  - `semanticColors` (`white`/`black`/`transparent`/etc.) stays hardcoded,
+    not re-themeable.
+  - Running this tool now executes the target project's `tailwind.config.js`
+    as a side effect of scanning (same as ESLint/Jest/webpack/PostCSS
+    already do with their own configs) — previously this tool only ever
+    parsed JSX via Babel, never executed anything.
 - **Touch target: no `min-w-*`/`min-h-*` fallback.** A minimum-width utility
   only guarantees a floor, not the actual rendered size — using it would
   mean guessing, so elements without explicit `w-*`+`h-*` are skipped
@@ -81,6 +102,10 @@ issues at a fraction of the engineering cost.
 src/
   theme/defaultPalette.ts         — Tailwind default color name -> hex map
   theme/spacingScale.ts           — Tailwind default spacing scale -> px map
+  theme/loadCustomTheme.ts        — finds/loads a project's tailwind.config.js/.cjs,
+                                     merges theme.extend.colors/spacing over the
+                                     defaults (resolveTheme() is the one function
+                                     each adapter calls)
   contrast/luminance.ts           — WCAG relative luminance + contrast ratio math
   parser/babelInterop.ts          — shared @babel/traverse CJS/ESM interop shim,
                                      parseJSX(), getStaticClassName()
@@ -96,6 +121,7 @@ src/
   rules/checkFocusIndicator.ts    — focus indicator violations (WCAG 2.4.7, AA)
   cli.ts                         — fast-glob scan, run all three checkers,
                                     print report, exit 1 on any violations (CI)
+  cliArgs.ts                     — flag parsing, including --config <path>
 ```
 
 Each check gets its **own independent Babel parse+traverse pass** over a

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -22,12 +22,18 @@ npm install --save-dev tailwind-a11y
 ## Usage
 
 ```bash
-npx tailwind-a11y                    # scans **/*.{jsx,tsx}
-npx tailwind-a11y "src/**/*.tsx"     # custom glob
-npx tailwind-a11y --verbose          # also reports what couldn't be checked, and why
-npx tailwind-a11y --version          # print the installed version
-npx tailwind-a11y --help             # usage and all options
+npx tailwind-a11y                              # scans **/*.{jsx,tsx}
+npx tailwind-a11y "src/**/*.tsx"               # custom glob
+npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
+npx tailwind-a11y --config ./tw.config.cjs     # use a specific tailwind.config instead of auto-detecting
+npx tailwind-a11y --version                    # print the installed version
+npx tailwind-a11y --help                       # usage and all options
 ```
+
+Custom `theme.extend.colors`/`theme.extend.spacing` in a `tailwind.config.js`/`.cjs`
+found in the current directory (or passed via `--config`) are read automatically, so
+colors and spacing outside Tailwind's defaults resolve too — not just the built-in
+palette.
 
 ```
 src/components/Card.tsx
@@ -54,7 +60,9 @@ When a case can't be resolved with confidence, it's skipped rather than guessed:
 
 - Ancestors beyond the immediate parent, or backgrounds set inside a separate component
 - Dynamic or computed `className` (ternaries, `clsx()`, template literals)
-- Custom theme colors/spacing not in Tailwind's default scales
+- A full `theme.colors`/`theme.spacing` replacement, `.mjs`/`.ts` configs, or
+  Tailwind v4's CSS-based `@theme` config (only `theme.extend` in a `.js`/`.cjs`
+  config is read — see [CLAUDE.md](./CLAUDE.md))
 - Color + opacity shorthand (`bg-white/50`)
 - Frameworks other than React/JSX
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
-import { relative, sep } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import { createRequire } from "node:module";
 import fg from "fast-glob";
 import { extractChecks, extractContrastSkips } from "./parser/extractClasses.js";
@@ -10,6 +10,7 @@ import { checkTouchTargets, type TouchTargetViolation } from "./rules/checkTouch
 import { extractFocusIndicatorChecks } from "./parser/extractFocusIndicators.js";
 import { checkFocusIndicators, type FocusIndicatorViolation } from "./rules/checkFocusIndicator.js";
 import { parseArgs, getHelpText } from "./cliArgs.js";
+import { resolveTheme } from "./theme/loadCustomTheme.js";
 
 // ../package.json resolves correctly from both src/ (dev) and dist/ (published).
 const require = createRequire(import.meta.url);
@@ -50,7 +51,7 @@ function groupByFile<T extends { file: string }>(items: T[]): Map<string, T[]> {
 }
 
 async function main(): Promise<void> {
-  const { help, version, verbose, patterns } = parseArgs(process.argv.slice(2));
+  const { help, version, verbose, config, configError: usageError, patterns } = parseArgs(process.argv.slice(2));
 
   if (help) {
     console.log(getHelpText());
@@ -59,6 +60,19 @@ async function main(): Promise<void> {
   if (version) {
     console.log(packageVersion);
     return;
+  }
+  if (usageError) {
+    console.error(`tailwind-a11y: ${usageError}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { palette, spacing, configError } = resolveTheme({
+    rootDir: process.cwd(),
+    configPath: config ? resolve(process.cwd(), config) : null,
+  });
+  if (configError) {
+    console.warn(`tailwind-a11y: ${configError}`);
   }
 
   const globPatterns = patterns.length > 0 ? patterns : ["**/*.{jsx,tsx}"];
@@ -83,16 +97,16 @@ async function main(): Promise<void> {
       const contrastChecks = extractChecks(code, file);
 
       violations.push(
-        ...checkContrast(contrastChecks),
-        ...checkTouchTargets(extractTouchTargetChecks(code, file)),
+        ...checkContrast(contrastChecks, palette),
+        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing)),
         ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
       );
 
       if (verbose) {
         skips.push(
           ...extractContrastSkips(code, file),
-          ...checkContrastValueSkips(contrastChecks),
-          ...extractTouchTargetSkips(code, file)
+          ...checkContrastValueSkips(contrastChecks, palette),
+          ...extractTouchTargetSkips(code, file, spacing)
         );
       }
     } catch (err) {

--- a/packages/tailwind-a11y/src/cliArgs.test.ts
+++ b/packages/tailwind-a11y/src/cliArgs.test.ts
@@ -3,7 +3,14 @@ import { parseArgs, getHelpText } from "./cliArgs.js";
 
 describe("parseArgs", () => {
   it("defaults to no flags and no patterns", () => {
-    expect(parseArgs([])).toEqual({ help: false, version: false, verbose: false, patterns: [] });
+    expect(parseArgs([])).toEqual({
+      help: false,
+      version: false,
+      verbose: false,
+      config: null,
+      configError: null,
+      patterns: [],
+    });
   });
 
   it("recognizes --verbose and its short form -v", () => {
@@ -31,13 +38,42 @@ describe("parseArgs", () => {
     expect(result.verbose).toBe(true);
     expect(result.patterns).toEqual(["src/**/*.tsx", "app/**/*.jsx"]);
   });
+
+  it("consumes --config's value and excludes both from patterns", () => {
+    const result = parseArgs(["--config", "./tailwind.config.cjs", "src/**/*.tsx"]);
+    expect(result.config).toBe("./tailwind.config.cjs");
+    expect(result.configError).toBeNull();
+    expect(result.patterns).toEqual(["src/**/*.tsx"]);
+  });
+
+  it("reports a usage error when --config is the last argument", () => {
+    const result = parseArgs(["--config"]);
+    expect(result.config).toBeNull();
+    expect(result.configError).toBe("--config requires a path argument");
+  });
+
+  it("reports a usage error when --config is immediately followed by another flag", () => {
+    const result = parseArgs(["--config", "--verbose"]);
+    expect(result.config).toBeNull();
+    expect(result.configError).toBe("--config requires a path argument");
+    // The flag itself still gets recognized on its own, not swallowed.
+    expect(result.verbose).toBe(true);
+  });
+
+  it("works alongside other flags and patterns in any order", () => {
+    const result = parseArgs(["--verbose", "--config", "tw.config.js", "src/**/*.tsx"]);
+    expect(result.verbose).toBe(true);
+    expect(result.config).toBe("tw.config.js");
+    expect(result.patterns).toEqual(["src/**/*.tsx"]);
+  });
 });
 
 describe("getHelpText", () => {
-  it("documents all three flags", () => {
+  it("documents all flags", () => {
     const text = getHelpText();
     expect(text).toContain("--verbose");
     expect(text).toContain("--version");
     expect(text).toContain("--help");
+    expect(text).toContain("--config");
   });
 });

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -5,6 +5,8 @@ export interface ParsedArgs {
   help: boolean;
   version: boolean;
   verbose: boolean;
+  config: string | null;
+  configError: string | null;
   patterns: string[];
 }
 
@@ -14,14 +16,18 @@ Static analysis for Tailwind CSS accessibility violations -- color contrast,
 touch target size, and focus indicator removal.
 
 Options:
-  -v, --verbose   Also report what couldn't be checked, and why
-  -V, --version   Print the version number
-  -h, --help      Print this help message
+  -v, --verbose      Also report what couldn't be checked, and why
+  -V, --version      Print the version number
+  -h, --help         Print this help message
+      --config <path>  Path to a tailwind.config.js/.cjs to read custom
+                        theme colors/spacing from (default: auto-detected
+                        in the current directory)
 
 Examples:
   tailwind-a11y                    Scan **/*.{jsx,tsx} from the current directory
   tailwind-a11y "src/**/*.tsx"     Scan a custom glob pattern
   tailwind-a11y --verbose          Also report skipped/unresolvable cases
+  tailwind-a11y --config ./tailwind.config.cjs
 `;
 
 export function getHelpText(): string {
@@ -33,10 +39,35 @@ export function getHelpText(): string {
 const FLAGS = new Set(["--verbose", "-v", "--version", "-V", "--help", "-h"]);
 
 export function parseArgs(argv: string[]): ParsedArgs {
+  let config: string | null = null;
+  let configError: string | null = null;
+  const patterns: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg !== "--config") {
+      if (!FLAGS.has(arg)) patterns.push(arg);
+      continue;
+    }
+
+    const value = argv[i + 1];
+    // A missing value or one that looks like another flag (starts with "-")
+    // must not be silently swallowed as a bogus path -- report a usage error
+    // instead of guessing.
+    if (value === undefined || value.startsWith("-")) {
+      configError = "--config requires a path argument";
+    } else {
+      config = value;
+      i++; // consume the value too, so it isn't also treated as a glob pattern
+    }
+  }
+
   return {
     help: argv.includes("--help") || argv.includes("-h"),
     version: argv.includes("--version") || argv.includes("-V"),
     verbose: argv.includes("--verbose") || argv.includes("-v"),
-    patterns: argv.filter((a) => !FLAGS.has(a)),
+    config,
+    configError,
+    patterns,
   };
 }

--- a/packages/tailwind-a11y/src/index.ts
+++ b/packages/tailwind-a11y/src/index.ts
@@ -5,3 +5,13 @@ export { checkTouchTargets, type TouchTargetViolation } from "./rules/checkTouch
 export { extractFocusIndicatorChecks, type FocusIndicatorCheck } from "./parser/extractFocusIndicators.js";
 export { checkFocusIndicators, type FocusIndicatorViolation } from "./rules/checkFocusIndicator.js";
 export { hexToRgb, contrastRatio, meetsWCAG, requiredRatio, type RGB } from "./contrast/luminance.js";
+export {
+  resolveTheme,
+  findTailwindConfig,
+  loadCustomTheme,
+  mergePalette,
+  mergeSpacing,
+  type ResolvedTheme,
+  type RawCustomTheme,
+} from "./theme/loadCustomTheme.js";
+export type { Palette, ColorScale } from "./theme/defaultPalette.js";

--- a/packages/tailwind-a11y/src/parser/extractTouchTargets.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractTouchTargets.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { extractTouchTargetChecks, extractTouchTargetSkips } from "./extractTouchTargets.js";
+import { spacingScale } from "../theme/spacingScale.js";
+import { mergeSpacing } from "../theme/loadCustomTheme.js";
 
 describe("extractTouchTargetChecks", () => {
   it("catches a 16x16 button", () => {
@@ -93,6 +95,23 @@ describe("extractTouchTargetChecks", () => {
   });
 });
 
+describe("extractTouchTargetChecks with a custom spacing scale", () => {
+  const customSpacing = mergeSpacing(spacingScale, { "18": 72 }); // 4.5rem
+
+  it("resolves a custom spacing token that a default-scale-only call would skip", () => {
+    const code = `const C = () => <button className="w-18 h-18">x</button>;`;
+    const checks = extractTouchTargetChecks(code, "fake.tsx", customSpacing);
+    expect(checks).toEqual([
+      { file: "fake.tsx", line: 1, tagName: "button", widthClass: "w-18", heightClass: "h-18", widthPx: 72, heightPx: 72 },
+    ]);
+  });
+
+  it("still skips the same token when no custom spacing is passed", () => {
+    const code = `const C = () => <button className="w-18 h-18">x</button>;`;
+    expect(extractTouchTargetChecks(code, "fake.tsx")).toEqual([]);
+  });
+});
+
 describe("extractTouchTargetSkips", () => {
   it("flags a width with no height", () => {
     const code = `const C = () => <button className="w-4">x</button>;`;
@@ -130,5 +149,11 @@ describe("extractTouchTargetSkips", () => {
   it("does not flag non-interactive elements", () => {
     const code = `const C = () => <div className="w-4">x</div>;`;
     expect(extractTouchTargetSkips(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("does not report a skip once a custom spacing scale resolves the token", () => {
+    const code = `const C = () => <button className="w-18 h-18">x</button>;`;
+    const customSpacing = mergeSpacing(spacingScale, { "18": 72 });
+    expect(extractTouchTargetSkips(code, "fake.tsx", customSpacing)).toEqual([]);
   });
 });

--- a/packages/tailwind-a11y/src/parser/extractTouchTargets.ts
+++ b/packages/tailwind-a11y/src/parser/extractTouchTargets.ts
@@ -58,7 +58,11 @@ function isInlineInText(path: NodePath<t.JSXElement>): boolean {
   return isMeaningfulText(siblings[index - 1]) || isMeaningfulText(siblings[index + 1]);
 }
 
-export function extractTouchTargetChecks(code: string, filePath: string): TouchTargetCheck[] {
+export function extractTouchTargetChecks(
+  code: string,
+  filePath: string,
+  spacing: Record<string, number> = spacingScale
+): TouchTargetCheck[] {
   const ast = parseJSX(code, filePath);
   if (!ast) return [];
 
@@ -77,8 +81,8 @@ export function extractTouchTargetChecks(code: string, filePath: string): TouchT
       const height = lastSizeToken(tokens, "h");
       if (!width || !height) return; // either dimension missing/dynamic — skip, don't guess
 
-      const widthPx = spacingScale[width.value];
-      const heightPx = spacingScale[height.value];
+      const widthPx = spacing[width.value];
+      const heightPx = spacing[height.value];
       if (widthPx === undefined || heightPx === undefined) return; // arbitrary/keyword/fraction — skip
 
       if (isInlineInText(path)) return; // WCAG 2.5.8 inline exception — exempt, not a violation
@@ -110,7 +114,11 @@ export interface TouchTargetSkip {
 // fraction). Elements with neither w-* nor h-* at all aren't reported —
 // that's the overwhelming majority of interactive elements and would be
 // pure noise, not a meaningful skip.
-export function extractTouchTargetSkips(code: string, filePath: string): TouchTargetSkip[] {
+export function extractTouchTargetSkips(
+  code: string,
+  filePath: string,
+  spacing: Record<string, number> = spacingScale
+): TouchTargetSkip[] {
   const ast = parseJSX(code, filePath);
   if (!ast) return [];
 
@@ -138,11 +146,11 @@ export function extractTouchTargetSkips(code: string, filePath: string): TouchTa
         return;
       }
 
-      const widthPx = spacingScale[width.value];
-      const heightPx = spacingScale[height.value];
+      const widthPx = spacing[width.value];
+      const heightPx = spacing[height.value];
       if (widthPx === undefined || heightPx === undefined) {
         const bad = widthPx === undefined ? width.raw : height.raw;
-        skips.push({ file: filePath, line, reason: `${bad} is not in the default spacing scale (arbitrary, keyword, or fraction value) — skipped` });
+        skips.push({ file: filePath, line, reason: `${bad} is not in the resolved spacing scale (arbitrary, keyword, or fraction value) — skipped` });
       }
     },
   });

--- a/packages/tailwind-a11y/src/rules/checkContrast.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { checkContrast, checkContrastValueSkips, suggestContrastFix } from "./checkContrast.js";
 import { extractChecks } from "../parser/extractClasses.js";
+import { defaultPalette } from "../theme/defaultPalette.js";
+import { mergePalette } from "../theme/loadCustomTheme.js";
 
 describe("checkContrast", () => {
   it("flags a known low-contrast pair", () => {
@@ -87,6 +89,25 @@ describe("checkContrast", () => {
   });
 });
 
+describe("checkContrast with a custom palette", () => {
+  const customPalette = mergePalette(defaultPalette, { brand: { "500": "#9ca3af" } }); // same hex as gray-400
+
+  it("resolves a custom-theme color that a default-palette-only call would skip", () => {
+    const violations = checkContrast(
+      [{ file: "f.tsx", line: 1, textColorClass: "text-brand-500", bgColorClass: "bg-white", bgSource: "self" }],
+      customPalette
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  it("still skips the same class when no custom palette is passed", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-brand-500", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toEqual([]);
+  });
+});
+
 describe("checkContrastValueSkips", () => {
   it("reports a skip for an unrecognized custom color", () => {
     const skips = checkContrastValueSkips([
@@ -108,6 +129,15 @@ describe("checkContrastValueSkips", () => {
     const skips = checkContrastValueSkips([
       { file: "f.tsx", line: 1, textColorClass: "text-gray-400", bgColorClass: "bg-white", bgSource: "self" },
     ]);
+    expect(skips).toEqual([]);
+  });
+
+  it("does not report a skip once a custom palette resolves the color", () => {
+    const customPalette = mergePalette(defaultPalette, { brand: { "500": "#9ca3af" } });
+    const skips = checkContrastValueSkips(
+      [{ file: "f.tsx", line: 1, textColorClass: "text-brand-500", bgColorClass: "bg-white", bgSource: "self" }],
+      customPalette
+    );
     expect(skips).toEqual([]);
   });
 });
@@ -164,6 +194,15 @@ describe("suggestContrastFix", () => {
     const fix = suggestContrastFix("text-gray-400", "bg-white", 4.5);
     expect(fix).not.toBeNull();
     expect(fix?.textClass).not.toBe("text-gray-400");
+    expect(fix?.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("finds a fix within a custom-theme scale that the default palette doesn't have", () => {
+    const customPalette = mergePalette(defaultPalette, {
+      brand: { "400": "#9ca3af", "700": "#374151" }, // same hex as gray-400/gray-700
+    });
+    const fix = suggestContrastFix("text-brand-400", "bg-white", 4.5, customPalette);
+    expect(fix?.textClass).toBe("text-brand-700");
     expect(fix?.ratio).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/packages/tailwind-a11y/src/rules/checkContrast.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.ts
@@ -1,5 +1,6 @@
 import { contrastRatio, hexToRgb, meetsWCAG, requiredRatio } from "../contrast/luminance.js";
 import { defaultPalette, semanticColors } from "../theme/defaultPalette.js";
+import type { Palette } from "../theme/defaultPalette.js";
 import type { ContrastCheck } from "../parser/extractClasses.js";
 
 export interface ContrastViolation {
@@ -15,7 +16,7 @@ export interface ContrastViolation {
   suggestedRatio?: number;
 }
 
-export function resolveColorValue(utilityClass: string): string | null {
+export function resolveColorValue(utilityClass: string, palette: Palette = defaultPalette): string | null {
   const match = /^(?:text|bg)-(.+)$/.exec(utilityClass);
   if (!match) return null;
   const token = match[1];
@@ -29,15 +30,15 @@ export function resolveColorValue(utilityClass: string): string | null {
 
   const [scale, shade] = token.split("-");
   if (!scale || !shade) return null;
-  return defaultPalette[scale]?.[shade] ?? null; // unknown/custom color — skip
+  return palette[scale]?.[shade] ?? null; // unknown/custom color — skip
 }
 
-export function checkContrast(checks: ContrastCheck[]): ContrastViolation[] {
+export function checkContrast(checks: ContrastCheck[], palette: Palette = defaultPalette): ContrastViolation[] {
   const violations: ContrastViolation[] = [];
 
   for (const check of checks) {
-    const textHex = resolveColorValue(check.textColorClass);
-    const bgHex = resolveColorValue(check.bgColorClass);
+    const textHex = resolveColorValue(check.textColorClass, palette);
+    const bgHex = resolveColorValue(check.bgColorClass, palette);
     if (!textHex || !bgHex) continue;
 
     const textRgb = hexToRgb(textHex);
@@ -48,7 +49,7 @@ export function checkContrast(checks: ContrastCheck[]): ContrastViolation[] {
     const required = requiredRatio("AA", false); // v1: large-text detection deferred
 
     if (!meetsWCAG(ratio, "AA", false)) {
-      const fix = suggestContrastFix(check.textColorClass, check.bgColorClass, required);
+      const fix = suggestContrastFix(check.textColorClass, check.bgColorClass, required, palette);
       violations.push({
         type: "contrast",
         file: check.file,
@@ -81,15 +82,20 @@ const TEXT_SCALE_SHADE_RE = /^text-([a-z]+)-(\d+)$/;
 // darker is the fix a human reaches for. The original shade can never win:
 // it's in this same candidate list at distance 0, and this recomputes the
 // identical unrounded ratio comparison that just failed.
-export function suggestContrastFix(textClass: string, bgClass: string, required: number): ContrastFix | null {
+export function suggestContrastFix(
+  textClass: string,
+  bgClass: string,
+  required: number,
+  palette: Palette = defaultPalette
+): ContrastFix | null {
   const match = TEXT_SCALE_SHADE_RE.exec(textClass);
   if (!match) return null; // text-white, text-[#eee], text-gray-400/50 — no suggestion
 
   const [, scale, shade] = match;
-  const shades = defaultPalette[scale];
+  const shades = palette[scale];
   if (!shades?.[shade]) return null; // custom scale, or a decoy like text-opacity-50
 
-  const bgHex = resolveColorValue(bgClass);
+  const bgHex = resolveColorValue(bgClass, palette);
   const bgRgb = bgHex ? hexToRgb(bgHex) : null;
   if (!bgRgb) return null;
 
@@ -120,12 +126,15 @@ export interface ContrastValueSkip {
 // non-hex arbitrary value, opacity shorthand) — surfaced separately from
 // extractContrastSkips' component-boundary case, since this one already has
 // a full text/bg pair and only failed at value resolution.
-export function checkContrastValueSkips(checks: ContrastCheck[]): ContrastValueSkip[] {
+export function checkContrastValueSkips(
+  checks: ContrastCheck[],
+  palette: Palette = defaultPalette
+): ContrastValueSkip[] {
   const skips: ContrastValueSkip[] = [];
 
   for (const check of checks) {
-    const textHex = resolveColorValue(check.textColorClass);
-    const bgHex = resolveColorValue(check.bgColorClass);
+    const textHex = resolveColorValue(check.textColorClass, palette);
+    const bgHex = resolveColorValue(check.bgColorClass, palette);
     if (textHex && bgHex) continue;
 
     const unresolved = !textHex ? check.textColorClass : check.bgColorClass;

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findTailwindConfig,
+  loadCustomTheme,
+  mergePalette,
+  mergeSpacing,
+  resolveTheme,
+} from "./loadCustomTheme.js";
+import { defaultPalette } from "./defaultPalette.js";
+import { spacingScale } from "./spacingScale.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tailwind-a11y-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("findTailwindConfig", () => {
+  it("finds tailwind.config.js", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), "module.exports = {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.js"));
+  });
+
+  it("finds tailwind.config.cjs when .js is absent", () => {
+    writeFileSync(join(dir, "tailwind.config.cjs"), "module.exports = {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.cjs"));
+  });
+
+  it("prefers .js over .cjs when both are present", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), "module.exports = {};");
+    writeFileSync(join(dir, "tailwind.config.cjs"), "module.exports = {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.js"));
+  });
+
+  it("returns null when neither exists", () => {
+    expect(findTailwindConfig(dir)).toBeNull();
+  });
+});
+
+describe("loadCustomTheme", () => {
+  it("extracts theme.extend.colors and theme.extend.spacing", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: {
+        colors: { brand: { 500: "#3490dc" } },
+        spacing: { "18": "4.5rem" },
+      } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+      spacing: { "18": 72 },
+    });
+  });
+
+  it("returns {} for a config with no theme.extend", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(configPath, "module.exports = {};");
+    expect(loadCustomTheme(configPath)).toEqual({});
+  });
+
+  it("returns null for a missing file", () => {
+    expect(loadCustomTheme(join(dir, "nope.js"))).toBeNull();
+  });
+
+  it("returns null for a config that throws on load", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(configPath, "throw new Error('boom');");
+    expect(loadCustomTheme(configPath)).toBeNull();
+  });
+
+  it('returns null for a CJS config in a "type": "module" project (ERR_REQUIRE_ESM)', () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ type: "module" }));
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(configPath, "module.exports = { theme: { extend: {} } };");
+    expect(loadCustomTheme(configPath)).toBeNull();
+  });
+
+  it("skips a flat string color value (no class syntax would ever resolve it)", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(configPath, `module.exports = { theme: { extend: { colors: { brand: "#3490dc" } } } };`);
+    expect(loadCustomTheme(configPath)).toEqual({});
+  });
+
+  it("skips a DEFAULT key within a color scale but keeps the real shades", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: { brand: { DEFAULT: "#3490dc", 500: "#3490dc" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#3490dc" } } });
+  });
+
+  it("skips a non-hex color value", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "rgb(52 144 220)" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({});
+  });
+
+  it("skips a non-rem/px spacing value", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(configPath, `module.exports = { theme: { extend: { spacing: { "18": "50%" } } } };`);
+    expect(loadCustomTheme(configPath)).toEqual({});
+  });
+
+  it("reflects an edit to the same path (require cache is busted)", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "#111111" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#111111" } } });
+
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "#222222" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#222222" } } });
+  });
+
+  it("reflects an edit to a file the config itself requires (regression: nested require-cache busting)", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    const colorsPath = join(dir, "colors.js");
+    writeFileSync(colorsPath, `module.exports = { brand: { 500: "#111111" } };`);
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: require("./colors.js") } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#111111" } } });
+
+    writeFileSync(colorsPath, `module.exports = { brand: { 500: "#222222" } };`);
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#222222" } } });
+  });
+});
+
+describe("mergePalette", () => {
+  it("returns base unchanged when extend is undefined", () => {
+    expect(mergePalette(defaultPalette)).toBe(defaultPalette);
+  });
+
+  it("adds a new scale wholesale", () => {
+    const merged = mergePalette(defaultPalette, { brand: { "500": "#3490dc" } });
+    expect(merged.brand).toEqual({ "500": "#3490dc" });
+    expect(merged.gray).toBe(defaultPalette.gray);
+  });
+
+  it("extends an existing scale without dropping its other shades", () => {
+    const merged = mergePalette(defaultPalette, { gray: { "1000": "#000000" } });
+    expect(merged.gray["1000"]).toBe("#000000");
+    expect(merged.gray["400"]).toBe(defaultPalette.gray["400"]);
+  });
+});
+
+describe("mergeSpacing", () => {
+  it("returns base unchanged when extend is undefined", () => {
+    expect(mergeSpacing(spacingScale)).toBe(spacingScale);
+  });
+
+  it("adds new tokens alongside the defaults", () => {
+    const merged = mergeSpacing(spacingScale, { "18": 72 });
+    expect(merged["18"]).toBe(72);
+    expect(merged["4"]).toBe(spacingScale["4"]);
+  });
+});
+
+describe("resolveTheme", () => {
+  it("returns the untouched defaults when rootDir is null", () => {
+    expect(resolveTheme({ rootDir: null })).toEqual({ palette: defaultPalette, spacing: spacingScale });
+  });
+
+  it("returns the untouched defaults when no config is found in rootDir", () => {
+    expect(resolveTheme({ rootDir: dir })).toEqual({ palette: defaultPalette, spacing: spacingScale });
+  });
+
+  it("auto-detects and merges a config found in rootDir", () => {
+    writeFileSync(
+      join(dir, "tailwind.config.js"),
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "#3490dc" } } } } };`
+    );
+    const result = resolveTheme({ rootDir: dir });
+    expect(result.palette.brand).toEqual({ "500": "#3490dc" });
+    expect(result.configError).toBeUndefined();
+  });
+
+  it("uses an explicit configPath over auto-detection", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), `module.exports = {};`);
+    const explicitPath = join(dir, "custom.config.js");
+    writeFileSync(
+      explicitPath,
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "#abcdef" } } } } };`
+    );
+    const result = resolveTheme({ rootDir: dir, configPath: explicitPath });
+    expect(result.palette.brand).toEqual({ "500": "#abcdef" });
+  });
+
+  it("sets configError when an explicit configPath fails to load, and still returns defaults", () => {
+    const explicitPath = join(dir, "does-not-exist.js");
+    const result = resolveTheme({ rootDir: dir, configPath: explicitPath });
+    expect(result.palette).toBe(defaultPalette);
+    expect(result.spacing).toBe(spacingScale);
+    expect(result.configError).toContain(explicitPath);
+  });
+
+  it("stays silent (no configError) when auto-detection finds a broken config", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), "throw new Error('boom');");
+    expect(resolveTheme({ rootDir: dir }).configError).toBeUndefined();
+  });
+});

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
@@ -1,0 +1,165 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import { hexToRgb } from "../contrast/luminance.js";
+import { defaultPalette } from "./defaultPalette.js";
+import { spacingScale } from "./spacingScale.js";
+import type { Palette } from "./defaultPalette.js";
+
+const CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
+
+// v1 only looks in the given directory itself -- no ancestor-directory search.
+// --config (CLI) / settings["tailwind-a11y"].configPath (ESLint) exist as
+// explicit escape hatches for projects where this isn't enough. `rootDir` must
+// be an absolute path.
+export function findTailwindConfig(rootDir: string): string | null {
+  for (const filename of CONFIG_FILENAMES) {
+    const candidate = join(rootDir, filename);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export interface RawCustomTheme {
+  colors?: Palette;
+  spacing?: Record<string, number>;
+}
+
+const SPACING_RE = /^-?[\d.]+(rem|px)$/;
+
+function parseSpacingValue(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const match = SPACING_RE.exec(value);
+  if (!match) return null; // em/%/vw/bare number/function -- skip, don't guess
+  const num = parseFloat(value);
+  return match[1] === "rem" ? num * 16 : num; // matches spacingScale.ts's 16px-root assumption
+}
+
+// Only plain hex-shade objects are accepted (e.g. `brand: { 500: '#3490dc' }`).
+// A flat string color (`brand: '#3490dc'`) or a `DEFAULT` key is skipped
+// entirely -- there's no class syntax ("bg-brand-DEFAULT" isn't real Tailwind)
+// that would ever resolve to it, so partially supporting it would be dead code.
+function parseColorScale(value: unknown): Record<string, string> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const shades: Record<string, string> = {};
+  for (const [shade, shadeValue] of Object.entries(value)) {
+    if (shade === "DEFAULT") continue; // no "bg-brand-DEFAULT" class syntax exists to resolve it
+    if (typeof shadeValue !== "string") continue;
+    if (hexToRgb(shadeValue) === null) continue; // not a hex value -- skip, don't guess
+    shades[shade] = shadeValue;
+  }
+  return Object.keys(shades).length > 0 ? shades : null;
+}
+
+// Loads a tailwind.config.js/.cjs and extracts only `theme.extend.colors` /
+// `theme.extend.spacing` -- v1 does not read a full `theme.colors`/`theme.spacing`
+// replacement, Tailwind v4's CSS-based `@theme` config, or .mjs/.ts configs (no
+// config-transpiling dependency exists in this package). `configPath` must be
+// an absolute path (require() resolves relative paths against this module's
+// own location, not the caller's cwd).
+//
+// Node's require() cache is busted before loading -- recursively, for the
+// config file *and* everything it required (e.g. a config that factors
+// tokens into a separate `require('./colors.js')`) -- without this, a
+// long-lived process (the VS Code extension host, an editor-integrated
+// ESLint server) would keep serving a stale value forever after the user
+// edits any file the config depends on, not just the config file itself.
+function bustRequireCache(require: NodeJS.Require, mod: NodeJS.Module, seen: Set<string>): void {
+  if (seen.has(mod.id)) return;
+  seen.add(mod.id);
+  for (const child of mod.children) bustRequireCache(require, child, seen);
+  delete require.cache[mod.id];
+}
+
+// Returns null only when the file itself couldn't be loaded (missing,
+// syntax error, ERR_REQUIRE_ESM for a "type": "module" project, or a config
+// that throws) -- a config that loads fine but has no theme.extend colors or
+// spacing returns {}, which callers must not treat as an error.
+export function loadCustomTheme(configPath: string): RawCustomTheme | null {
+  try {
+    const require = createRequire(import.meta.url);
+    const resolved = require.resolve(configPath);
+    const cached = require.cache[resolved];
+    if (cached) bustRequireCache(require, cached, new Set());
+    const config = require(resolved);
+    const extend = config?.theme?.extend ?? {};
+
+    const result: RawCustomTheme = {};
+
+    if (extend.colors && typeof extend.colors === "object") {
+      const colors: Palette = {};
+      for (const [scale, value] of Object.entries(extend.colors)) {
+        const shades = parseColorScale(value);
+        if (shades) colors[scale] = shades;
+      }
+      if (Object.keys(colors).length > 0) result.colors = colors;
+    }
+
+    if (extend.spacing && typeof extend.spacing === "object") {
+      const spacing: Record<string, number> = {};
+      for (const [token, value] of Object.entries(extend.spacing)) {
+        const px = parseSpacingValue(value);
+        if (px !== null) spacing[token] = px;
+      }
+      if (Object.keys(spacing).length > 0) result.spacing = spacing;
+    }
+
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+// New scale names are added wholesale; extending an existing scale merges
+// shade keys in without dropping the scale's other (default) shades.
+export function mergePalette(base: Palette, extend?: Palette): Palette {
+  if (!extend) return base;
+  const merged: Palette = { ...base };
+  for (const [scale, shades] of Object.entries(extend)) {
+    merged[scale] = { ...merged[scale], ...shades };
+  }
+  return merged;
+}
+
+export function mergeSpacing(
+  base: Record<string, number>,
+  extend?: Record<string, number>
+): Record<string, number> {
+  return extend ? { ...base, ...extend } : base;
+}
+
+export interface ResolvedTheme {
+  palette: Palette;
+  spacing: Record<string, number>;
+  configError?: string;
+}
+
+// configError is only ever set when a path was *explicitly* provided (CLI
+// --config flag or ESLint settings) and failed to load -- auto-detected
+// absence stays silent, matching the "avoid confusing noise in an unrelated
+// linter run" precedent already in the ESLint plugin's index.ts. `rootDir`
+// and `configPath` (if given) must be absolute paths.
+export function resolveTheme(opts: { rootDir: string | null; configPath?: string | null }): ResolvedTheme {
+  const explicitPath = opts.configPath ?? null;
+  const configPath = explicitPath ?? (opts.rootDir ? findTailwindConfig(opts.rootDir) : null);
+
+  if (!configPath) {
+    return { palette: defaultPalette, spacing: spacingScale };
+  }
+
+  const custom = loadCustomTheme(configPath);
+  if (custom === null) {
+    return explicitPath
+      ? {
+          palette: defaultPalette,
+          spacing: spacingScale,
+          configError: `could not load Tailwind config at ${explicitPath}`,
+        }
+      : { palette: defaultPalette, spacing: spacingScale };
+  }
+
+  return {
+    palette: mergePalette(defaultPalette, custom.colors),
+    spacing: mergeSpacing(spacingScale, custom.spacing),
+  };
+}

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -19,6 +19,10 @@ Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, a
 or [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
 instead — both treat the same findings as errors.
 
+A `tailwind.config.js`/`.cjs` in the open file's workspace folder is picked up
+automatically, so custom theme colors/spacing resolve the same way they do in the CLI
+and ESLint plugin.
+
 ## License
 
 MIT

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -48,7 +48,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.3.0"
+    "tailwind-a11y": "^0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -6,6 +6,7 @@ import {
   checkTouchTargets,
   extractFocusIndicatorChecks,
   checkFocusIndicators,
+  resolveTheme,
 } from "tailwind-a11y";
 import { formatViolation, type AnyViolation } from "./format.js";
 
@@ -67,9 +68,16 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
   const text = doc.getText();
   const file = doc.uri.fsPath;
 
+  // Resolved fresh on every call rather than cached -- fine performance-wise
+  // since edits are already 300ms-debounced, and it's what makes an edit to
+  // tailwind.config.js itself actually get picked up (relies on the engine's
+  // own require-cache busting in loadCustomTheme, not any caching here).
+  const rootDir = vscode.workspace.getWorkspaceFolder(doc.uri)?.uri.fsPath ?? null;
+  const { palette, spacing } = resolveTheme({ rootDir });
+
   const violations: AnyViolation[] = [
-    ...checkContrast(extractChecks(text, file)),
-    ...checkTouchTargets(extractTouchTargetChecks(text, file)),
+    ...checkContrast(extractChecks(text, file), palette),
+    ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing)),
     ...checkFocusIndicators(extractFocusIndicatorChecks(text, file)),
   ];
 


### PR DESCRIPTION
## Summary
- Colors and spacing outside Tailwind's default scales were previously always silently skipped, even when a project's own `tailwind.config.js` defines them. All three adapters now resolve `theme.extend.colors`/`theme.extend.spacing` from an auto-detected (or explicitly pointed-at) `tailwind.config.js`/`.cjs`, merged over the built-in defaults — one shared engine function (`resolveTheme()`), no detection logic duplicated across adapters.
- CLI: new `--config <path>` flag, falls back to auto-detecting a config in the current directory. ESLint: `settings["tailwind-a11y"].configPath`, falls back to `context.cwd`. VS Code: auto-detects from the active document's workspace folder. Existing behavior is unchanged when no custom theme is found — this is purely additive.
- Deliberate v1 scope cuts (documented in `packages/tailwind-a11y/CLAUDE.md`): only `theme.extend` (not a full `theme.colors`/`theme.spacing` replacement), only `.js`/`.cjs` configs, only plain hex color values and `rem`/`px` spacing values, no Tailwind v4 CSS-based `@theme` config, no ancestor-directory search.
- Node's `require()` cache is busted recursively for the config file *and* everything it requires (not just the top-level file) — a config that factors theme tokens into a separate file (e.g. `require('./colors.js')`, a common real-world pattern) still gets picked up fresh on every resolve, so a long-lived process like the VS Code extension host never serves a stale value after an edit.

## Versions
- `tailwind-a11y`: `0.3.1` → `0.4.0` (MINOR — new backward-compatible capability; every changed engine function takes the new palette/spacing as an optional parameter defaulting to the existing built-ins, so no existing call site or test needed to change)
- `eslint-plugin-tailwind-a11y`: dependency range `^0.3.0` → `^0.4.0` (mandatory — a MINOR engine bump falls outside the old caret range) **and** its own MINOR bump, since it gained real wiring (a new `settings["tailwind-a11y"].configPath` option), not just a dependency-range change
- `vscode-tailwind-a11y`: same reasoning — dependency range bump to `^0.4.0` plus its own MINOR bump for the new workspace-folder-based auto-detection

## Test plan
- [x] `npm test` across all three packages — 166 tests passing (146 + 16 + 4)
- [x] `npm run build -w vscode-tailwind-a11y` — bundle rebuilds successfully at 803.2kb
- [x] `npm run check:link` at root — workspace symlink resolution valid after all three version bumps
- [x] Real end-to-end smoke test: built CLI run against a real temp project, with and without `--config`/auto-detected `tailwind.config.js`
- [x] Real end-to-end smoke test: actual `eslint` CLI (not just `RuleTester`) run with and without `settings["tailwind-a11y"].configPath`, using two separate directories to isolate auto-detection from the explicit override
- [x] Regression test reproducing the require-cache staleness bug found in review (config that itself `require()`s a second file, edited after first load)