### PR TITLE
[v0.5.0] Resolve text-side color opacity modifiers in the contrast check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6643,10 +6643,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.4.0"
+        "tailwind-a11y": "^0.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6662,7 +6662,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6685,10 +6685,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.4.0"
+        "tailwind-a11y": "^0.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.4.0"
+    "tailwind-a11y": "^0.5.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -89,6 +89,34 @@ Tailwind-class-level sizing or focus-style analysis).
 - **Focus indicator: `focus:` and `focus-visible:` are merged** for the
   removal-vs-replacement comparison, since the standard accessible pattern
   (`focus:outline-none focus-visible:ring-2`) spans both variants.
+- **Contrast: opacity modifiers (`text-gray-400/50`) are resolved on the
+  *text* side only**, composited against the already-resolved (fully opaque)
+  background — see `resolveTextColorWithOpacity()`/`applyAlpha()` in
+  `rules/checkContrast.ts`/`contrast/luminance.ts`. Deliberate cuts:
+  - The *background* side (`bg-white/50` as the actual background) stays
+    unresolvable. Compositing it correctly requires knowing what's rendered
+    behind it (grandparent-or-beyond) — the same ancestor-walk this file
+    already scopes out for plain (non-opacity) backgrounds.
+  - `scale-shade/NN` (`text-gray-400/50`), semantic-word/NN (`text-white/50`,
+    `text-black/50`), and arbitrary-hex/NN (`text-[#eee]/50`) all resolve —
+    `COLOR_TOKEN` in `extractClasses.ts` extracts all three shapes with the
+    opacity suffix intact. (`text-white/NN`/`text-black/NN` specifically was
+    a real gap caught in review: the extraction regex initially only kept the
+    suffix on the scale-shade shape, silently dropping the semantic/arbitrary
+    cases with no `--verbose` trace at all — arguably the *more* common real
+    idiom than named-scale opacity, so leaving it out would have undercut
+    this feature's whole point.)
+  - Only a plain 0–100 integer percentage. An arbitrary bracket alpha
+    (`/[0.15]`) falls through unresolved.
+  - An out-of-range percentage (`/150`) is **clamped** to 0–100, not rejected
+    — real browsers clamp out-of-range CSS alpha the same way, so this
+    matches actual rendering rather than guessing. Rejecting it instead would
+    hide a real violation behind what's essentially a typo — the "shape looks
+    safe but isn't" failure class noted below.
+  - Exactly 0% (`/0`) is treated as unresolvable, like `text-transparent`
+    (`semanticColors.transparent` is already `null`) — not flagged as an
+    unconditional violation, since fully-invisible text isn't a contrast
+    problem in the same sense a merely-faint one is.
 
 These boundaries exist because the cross-component, dynamic-class, and
 whole-DOM-layout cases require whole-program or runtime analysis — a
@@ -114,9 +142,11 @@ src/
   parser/extractTouchTargets.ts   — w-*/h-* pairs on interactive elements
   parser/extractFocusIndicators.ts— focus:/focus-visible: classes on interactive elements
   rules/checkContrast.ts          — contrast violations (WCAG 1.4.3, AA);
-                                     also suggestContrastFix() — nearest
-                                     passing shade in the same color scale
-                                     (text side only, bg held fixed)
+                                     resolves a text-side opacity modifier
+                                     against the resolved (opaque) bg; also
+                                     suggestContrastFix() — nearest passing
+                                     shade in the same color scale (text side
+                                     only, bg and any opacity held fixed)
   rules/checkTouchTarget.ts       — touch target violations (WCAG 2.5.8, AA)
   rules/checkFocusIndicator.ts    — focus indicator violations (WCAG 2.4.7, AA)
   cli.ts                         — fast-glob scan, run all three checkers,

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -50,7 +50,7 @@ Exits `1` on violations — safe to use as a CI gate.
 
 | Check | WCAG | Detects |
 |---|---|---|
-| Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent; suggests the nearest passing shade |
+| Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent, including a text-side opacity modifier (`text-gray-400/50`) composited against the background; suggests the nearest passing shade |
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
@@ -63,7 +63,10 @@ When a case can't be resolved with confidence, it's skipped rather than guessed:
 - A full `theme.colors`/`theme.spacing` replacement, `.mjs`/`.ts` configs, or
   Tailwind v4's CSS-based `@theme` config (only `theme.extend` in a `.js`/`.cjs`
   config is read — see [CLAUDE.md](./CLAUDE.md))
-- Color + opacity shorthand (`bg-white/50`)
+- Opacity shorthand on the **background** side (`bg-white/50` as the actual
+  background) — the rendered backdrop is layout-dependent and out of scope,
+  same reasoning as the ancestor-parent limit above. **Text-side** opacity
+  (`text-gray-400/50`) *is* resolved, composited against the (opaque) background.
 - Frameworks other than React/JSX
 
 `--verbose` reports what was skipped and why — a skip is not a pass. Full rationale in

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/contrast/luminance.test.ts
+++ b/packages/tailwind-a11y/src/contrast/luminance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { contrastRatio, hexToRgb, meetsWCAG, relativeLuminance, requiredRatio } from "./luminance.js";
+import { applyAlpha, contrastRatio, hexToRgb, meetsWCAG, relativeLuminance, requiredRatio } from "./luminance.js";
 
 describe("hexToRgb", () => {
   it("parses 6-digit hex with #", () => {
@@ -43,6 +43,29 @@ describe("contrastRatio", () => {
   it("matches the classic #767676-on-white borderline-AA example", () => {
     const ratio = contrastRatio(hexToRgb("#767676")!, hexToRgb("#ffffff")!);
     expect(ratio).toBeCloseTo(4.54, 1);
+  });
+});
+
+describe("applyAlpha", () => {
+  const black = { r: 0, g: 0, b: 0 };
+  const white = { r: 255, g: 255, b: 255 };
+
+  it("alpha 0 returns the background unchanged", () => {
+    expect(applyAlpha(black, 0, white)).toEqual(white);
+  });
+
+  it("alpha 1 returns the foreground unchanged", () => {
+    expect(applyAlpha(black, 1, white)).toEqual(black);
+  });
+
+  it("alpha 0.5 is the midpoint", () => {
+    expect(applyAlpha(black, 0.5, white)).toEqual({ r: 128, g: 128, b: 128 });
+  });
+
+  it("blends each channel independently (catches an r/g/b copy-paste bug)", () => {
+    const fg = { r: 200, g: 100, b: 0 };
+    const bg = { r: 0, g: 100, b: 200 };
+    expect(applyAlpha(fg, 0.5, bg)).toEqual({ r: 100, g: 100, b: 100 });
   });
 });
 

--- a/packages/tailwind-a11y/src/contrast/luminance.ts
+++ b/packages/tailwind-a11y/src/contrast/luminance.ts
@@ -25,6 +25,18 @@ export function hexToRgb(hex: string): RGB | null {
   };
 }
 
+// Standard "src-over" compositing of a foreground at `alpha` opacity over an
+// opaque background, in gamma-encoded sRGB space (0-255 channels) -- matches
+// how browsers actually composite CSS opacity, no linear-light conversion
+// needed for a simple two-layer blend.
+export function applyAlpha(fg: RGB, alpha: number, bg: RGB): RGB {
+  return {
+    r: Math.round(alpha * fg.r + (1 - alpha) * bg.r),
+    g: Math.round(alpha * fg.g + (1 - alpha) * bg.g),
+    b: Math.round(alpha * fg.b + (1 - alpha) * bg.b),
+  };
+}
+
 function channelLuminance(channel: number): number {
   const c = channel / 255;
   return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;

--- a/packages/tailwind-a11y/src/parser/extractClasses.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.test.ts
@@ -79,4 +79,20 @@ describe("extractChecks", () => {
       { file: "fake.tsx", line: 1, textColorClass: "text-gray-400", bgColorClass: "bg-white", bgSource: "self" },
     ]);
   });
+
+  it("extracts a semantic color with an opacity modifier (text-white/NN, the most common real idiom)", () => {
+    const code = `const C = () => <p className="text-white/40 bg-gray-800">x</p>;`;
+    const checks = extractChecks(code, "fake.tsx");
+    expect(checks).toEqual([
+      { file: "fake.tsx", line: 1, textColorClass: "text-white/40", bgColorClass: "bg-gray-800", bgSource: "self" },
+    ]);
+  });
+
+  it("extracts an arbitrary hex color with an opacity modifier", () => {
+    const code = `const C = () => <p className="text-[#eeeeee]/40 bg-gray-800">x</p>;`;
+    const checks = extractChecks(code, "fake.tsx");
+    expect(checks).toEqual([
+      { file: "fake.tsx", line: 1, textColorClass: "text-[#eeeeee]/40", bgColorClass: "bg-gray-800", bgSource: "self" },
+    ]);
+  });
 });

--- a/packages/tailwind-a11y/src/parser/extractClasses.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.ts
@@ -12,8 +12,14 @@ export interface ContrastCheck {
 // Positive shape filter for "does this look like a color utility", not a
 // blocklist — Tailwind heavily overloads the text-*/bg-* prefix (text-lg,
 // bg-cover, bg-gradient-to-r, ...) and an exclude-list would be fragile
-// across versions.
-const COLOR_TOKEN = /^\[(#[0-9a-fA-F]{3,8})\]$|^[a-z]+-\d{2,3}(\/\d{1,3})?$|^(white|black|transparent|current|inherit)$/;
+// across versions. Every alternative allows an optional trailing opacity
+// modifier (/NN) so text-white/40, text-[#eee]/40, and text-gray-400/40 are
+// all extracted with the suffix intact -- text-white/black-with-opacity is
+// an extremely common real idiom, more so than the named-scale case, and
+// dropping it here would make the contrast checker's opacity support (see
+// rules/checkContrast.ts) silently inapplicable to the most common case.
+const COLOR_TOKEN =
+  /^\[(#[0-9a-fA-F]{3,8})\](\/\d{1,3})?$|^[a-z]+-\d{2,3}(\/\d{1,3})?$|^(white|black|transparent|current|inherit)(\/\d{1,3})?$/;
 
 // opacity-{N} (e.g. bg-opacity-50, text-opacity-50) matches the same
 // "word-number" shape as a color token but isn't one — without this

--- a/packages/tailwind-a11y/src/rules/checkContrast.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.test.ts
@@ -89,6 +89,89 @@ describe("checkContrast", () => {
   });
 });
 
+describe("checkContrast with a text-side opacity modifier", () => {
+  it("flags a previously-invisible violation: dark text at low opacity reads as light", () => {
+    // text-gray-900 alone passes easily against white; at 30% opacity it
+    // composites to a light gray that fails -- this was silently skipped
+    // entirely before opacity support existed.
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-900/30", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].ratio).toBeCloseTo(1.94, 2);
+  });
+
+  it("/100 produces the same computed result as no modifier at all", () => {
+    const [plain] = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    const [withModifier] = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/100", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(withModifier.ratio).toBe(plain.ratio);
+    expect(withModifier.suggestion).toBe(plain.suggestion);
+    expect(withModifier.suggestedRatio).toBe(plain.suggestedRatio);
+  });
+
+  it("clamps an out-of-range percentage to 100 instead of skipping it (matches real browser clamping)", () => {
+    const [over100] = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/150", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    const [at100] = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/100", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(over100.ratio).toBe(at100.ratio);
+  });
+
+  it("treats exactly 0% opacity as unresolvable, like text-transparent -- not an unconditional violation", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/0", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("still skips when the background itself has an opacity modifier (unknown backdrop, out of scope)", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/50", bgColorClass: "bg-white/50", bgSource: "self" },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("fails safe on a shape the extractor could never produce (double opacity suffix)", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/50/50", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("composes end-to-end with extractChecks through the full pipeline", () => {
+    const code = `
+      const C = () => (
+        <div className="bg-white">
+          <p className="text-gray-900/30">low contrast once you account for opacity</p>
+        </div>
+      );
+    `;
+    const violations = checkContrast(extractChecks(code, "fake.tsx"));
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ textClass: "text-gray-900/30", bgClass: "bg-white" });
+    expect(violations[0].ratio).toBeCloseTo(1.94, 2);
+  });
+
+  it("resolves a semantic color with opacity (text-white/NN) end-to-end -- the most common real idiom", () => {
+    // Caught in independent review: the extraction regex originally only let
+    // scale-shade/NN tokens (text-gray-400/50) through with the opacity
+    // suffix intact -- text-white/NN and text-black/NN, arguably the more
+    // common real pattern, were silently dropped before ever reaching this
+    // opacity logic. Fixed in extractClasses.ts's COLOR_TOKEN regex.
+    const code = `const C = () => <p className="text-white/40 bg-gray-800">dim text on dark background</p>;`;
+    const violations = checkContrast(extractChecks(code, "fake.tsx"));
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ textClass: "text-white/40", bgClass: "bg-gray-800" });
+    expect(violations[0].ratio).toBeCloseTo(3.63, 2);
+  });
+});
+
 describe("checkContrast with a custom palette", () => {
   const customPalette = mergePalette(defaultPalette, { brand: { "500": "#9ca3af" } }); // same hex as gray-400
 
@@ -140,6 +223,23 @@ describe("checkContrastValueSkips", () => {
     );
     expect(skips).toEqual([]);
   });
+
+  it("reports a distinct reason for exactly 0% opacity (not a generic 'unrecognized color')", () => {
+    const skips = checkContrastValueSkips([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-400/0", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(skips).toHaveLength(1);
+    expect(skips[0].reason).toContain("text-gray-400/0");
+    expect(skips[0].reason).toContain("fully transparent");
+  });
+
+  it("attributes a both-sides-unresolvable case to bg first (deliberate resolution order, not a random tie)", () => {
+    const skips = checkContrastValueSkips([
+      { file: "f.tsx", line: 1, textColorClass: "text-brand-500", bgColorClass: "bg-brand-50", bgSource: "self" },
+    ]);
+    expect(skips).toHaveLength(1);
+    expect(skips[0].reason).toContain("bg-brand-50");
+  });
 });
 
 describe("suggestContrastFix", () => {
@@ -168,8 +268,25 @@ describe("suggestContrastFix", () => {
     expect(suggestContrastFix("text-brand-500", "bg-white", 4.5)).toBeNull();
   });
 
-  it("returns null for opacity-modifier shorthand on the text class", () => {
+  it("returns null at 50% opacity on white -- no gray shade (not even black) reaches 4.5:1 at that alpha", () => {
+    // This still returns null, but for a different reason than before opacity
+    // support existed: it's now a computed result (every candidate shade was
+    // actually tried and failed at 50% alpha), not a regex short-circuit.
     expect(suggestContrastFix("text-gray-400/50", "bg-white", 4.5)).toBeNull();
+  });
+
+  it("finds a fix at an opacity where one is reachable, and preserves the opacity in the suggestion", () => {
+    const fix = suggestContrastFix("text-gray-400/80", "bg-white", 4.5);
+    expect(fix?.textClass).toBe("text-gray-600/80");
+    expect(fix?.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("returns null for exactly 0% opacity -- no shade change fixes total transparency", () => {
+    expect(suggestContrastFix("text-gray-400/0", "bg-white", 4.5)).toBeNull();
+  });
+
+  it("fails safe on a shape the extractor could never produce (double opacity suffix)", () => {
+    expect(suggestContrastFix("text-gray-400/50/50", "bg-white", 4.5)).toBeNull();
   });
 
   it("returns null for the opacity decoy token (same shape as a color, isn't one)", () => {

--- a/packages/tailwind-a11y/src/rules/checkContrast.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.ts
@@ -1,4 +1,5 @@
-import { contrastRatio, hexToRgb, meetsWCAG, requiredRatio } from "../contrast/luminance.js";
+import { applyAlpha, contrastRatio, hexToRgb, meetsWCAG, requiredRatio } from "../contrast/luminance.js";
+import type { RGB } from "../contrast/luminance.js";
 import { defaultPalette, semanticColors } from "../theme/defaultPalette.js";
 import type { Palette } from "../theme/defaultPalette.js";
 import type { ContrastCheck } from "../parser/extractClasses.js";
@@ -33,17 +34,49 @@ export function resolveColorValue(utilityClass: string, palette: Palette = defau
   return palette[scale]?.[shade] ?? null; // unknown/custom color — skip
 }
 
+// Splits a trailing Tailwind opacity modifier off a color utility class
+// (e.g. "text-gray-400/50" -> { base: "text-gray-400", alpha: 0.5 }). No
+// modifier -> alpha 1. Out-of-range (>100) is clamped rather than rejected --
+// real browsers clamp out-of-range CSS alpha to the nearest valid bound, so
+// "/150" genuinely renders identically to "/100"; silently skipping it
+// instead would hide a real violation behind what's essentially a typo. A
+// non-digit or malformed suffix falls through as { base: <the whole original
+// string>, alpha: 1 } -- base still contains the "/", so resolveColorValue's
+// existing guard rejects it downstream; this never needs to return null.
+function splitOpacityModifier(utilityClass: string): { base: string; alpha: number } {
+  const match = /^(.+)\/(\d{1,3})$/.exec(utilityClass);
+  if (!match) return { base: utilityClass, alpha: 1 };
+  const pct = Math.min(100, Math.max(0, Number(match[2])));
+  return { base: match[1], alpha: pct / 100 };
+}
+
+// Resolves a text-* class (with or without an opacity modifier) to the
+// effective color it actually renders as, composited against the already-
+// resolved (fully opaque) background. Only the text side supports opacity --
+// see resolveColorValue's own unconditional "/" rejection for why the
+// background side doesn't: compositing a semi-transparent background
+// correctly requires knowing what's rendered *behind* it, which is out of
+// scope the same way walking further up the ancestor chain is.
+function resolveTextColorWithOpacity(utilityClass: string, bgRgb: RGB, palette: Palette): RGB | null {
+  const { base, alpha } = splitOpacityModifier(utilityClass);
+  if (alpha === 0) return null; // fully transparent -- equivalent to text-transparent, nothing to check
+  const hex = resolveColorValue(base, palette);
+  const rgb = hex ? hexToRgb(hex) : null;
+  if (!rgb) return null;
+  return alpha < 1 ? applyAlpha(rgb, alpha, bgRgb) : rgb;
+}
+
 export function checkContrast(checks: ContrastCheck[], palette: Palette = defaultPalette): ContrastViolation[] {
   const violations: ContrastViolation[] = [];
 
   for (const check of checks) {
-    const textHex = resolveColorValue(check.textColorClass, palette);
     const bgHex = resolveColorValue(check.bgColorClass, palette);
-    if (!textHex || !bgHex) continue;
-
-    const textRgb = hexToRgb(textHex);
+    if (!bgHex) continue;
     const bgRgb = hexToRgb(bgHex);
-    if (!textRgb || !bgRgb) continue;
+    if (!bgRgb) continue;
+
+    const textRgb = resolveTextColorWithOpacity(check.textColorClass, bgRgb, palette);
+    if (!textRgb) continue;
 
     const ratio = contrastRatio(textRgb, bgRgb);
     const required = requiredRatio("AA", false); // v1: large-text detection deferred
@@ -74,22 +107,26 @@ export interface ContrastFix {
 
 const TEXT_SCALE_SHADE_RE = /^text-([a-z]+)-(\d+)$/;
 
-// Only the text shade moves — bg stays fixed, since text color is the more
-// commonly adjustable side in practice. Candidates come from the palette's
-// actual keys (not an assumed 50..950 enumeration), sorted nearest-first by
-// numeric distance from the original shade; ties favor the higher/darker
-// shade, since real failures here are overwhelmingly light-on-light and
-// darker is the fix a human reaches for. The original shade can never win:
-// it's in this same candidate list at distance 0, and this recomputes the
-// identical unrounded ratio comparison that just failed.
+// Only the text shade moves — bg and any opacity modifier on the text class
+// stay fixed, since text color is the more commonly adjustable side in
+// practice. Candidates come from the palette's actual keys (not an assumed
+// 50..950 enumeration), sorted nearest-first by numeric distance from the
+// original shade; ties favor the higher/darker shade, since real failures
+// here are overwhelmingly light-on-light and darker is the fix a human
+// reaches for. The original shade can never win: it's in this same
+// candidate list at distance 0, and this recomputes the identical unrounded
+// ratio comparison that just failed.
 export function suggestContrastFix(
   textClass: string,
   bgClass: string,
   required: number,
   palette: Palette = defaultPalette
 ): ContrastFix | null {
-  const match = TEXT_SCALE_SHADE_RE.exec(textClass);
-  if (!match) return null; // text-white, text-[#eee], text-gray-400/50 — no suggestion
+  const { base, alpha } = splitOpacityModifier(textClass);
+  if (alpha === 0) return null; // no shade change fixes total transparency
+
+  const match = TEXT_SCALE_SHADE_RE.exec(base);
+  if (!match) return null; // text-white, text-[#eee] — no suggestion
 
   const [, scale, shade] = match;
   const shades = palette[scale];
@@ -105,11 +142,17 @@ export function suggestContrastFix(
     .map(Number)
     .sort((a, b) => Math.abs(a - original) - Math.abs(b - original) || b - a);
 
+  // Only the shade searches candidates -- the original opacity is held
+  // fixed, exactly like bg is already held fixed.
   for (const candidate of candidates) {
     const rgb = hexToRgb(shades[String(candidate)]);
     if (!rgb) continue;
-    const ratio = contrastRatio(rgb, bgRgb);
-    if (ratio >= required) return { textClass: `text-${scale}-${candidate}`, ratio };
+    const effectiveRgb = alpha < 1 ? applyAlpha(rgb, alpha, bgRgb) : rgb;
+    const ratio = contrastRatio(effectiveRgb, bgRgb);
+    if (ratio >= required) {
+      const suggestedClass = alpha < 1 ? `text-${scale}-${candidate}/${Math.round(alpha * 100)}` : `text-${scale}-${candidate}`;
+      return { textClass: suggestedClass, ratio };
+    }
   }
 
   return null;
@@ -123,9 +166,17 @@ export interface ContrastValueSkip {
 
 // A candidate that extractChecks *did* find a background for, but whose
 // text or bg utility didn't resolve to a known value (custom theme color,
-// non-hex arbitrary value, opacity shorthand) — surfaced separately from
-// extractContrastSkips' component-boundary case, since this one already has
-// a full text/bg pair and only failed at value resolution.
+// non-hex arbitrary value, background-side opacity shorthand) — surfaced
+// separately from extractContrastSkips' component-boundary case, since this
+// one already has a full text/bg pair and only failed at value resolution.
+//
+// Resolves bg first, same order as checkContrast, so a bg-side failure and a
+// text-side failure are attributed to the correct class -- since text
+// resolution now depends on a known bg to composite against, resolving both
+// independently (as before) would make every bg failure also look like a
+// text failure. This does mean that when *both* sides are unresolvable for
+// unrelated reasons, bg is now named first (previously text always was) --
+// a deliberate, tested change, not an accidental side effect of reordering.
 export function checkContrastValueSkips(
   checks: ContrastCheck[],
   palette: Palette = defaultPalette
@@ -133,16 +184,35 @@ export function checkContrastValueSkips(
   const skips: ContrastValueSkip[] = [];
 
   for (const check of checks) {
-    const textHex = resolveColorValue(check.textColorClass, palette);
     const bgHex = resolveColorValue(check.bgColorClass, palette);
-    if (textHex && bgHex) continue;
+    const bgRgb = bgHex ? hexToRgb(bgHex) : null;
+    if (!bgRgb) {
+      skips.push({
+        file: check.file,
+        line: check.line,
+        reason: `${check.bgColorClass} is not a recognized color (custom theme color or unsupported arbitrary value) — skipped`,
+      });
+      continue;
+    }
 
-    const unresolved = !textHex ? check.textColorClass : check.bgColorClass;
-    skips.push({
-      file: check.file,
-      line: check.line,
-      reason: `${unresolved} is not a recognized color (custom theme color or unsupported arbitrary value) — skipped`,
-    });
+    const { alpha } = splitOpacityModifier(check.textColorClass);
+    if (alpha === 0) {
+      skips.push({
+        file: check.file,
+        line: check.line,
+        reason: `${check.textColorClass} is fully transparent (opacity 0) — nothing rendered to check`,
+      });
+      continue;
+    }
+
+    const textRgb = resolveTextColorWithOpacity(check.textColorClass, bgRgb, palette);
+    if (!textRgb) {
+      skips.push({
+        file: check.file,
+        line: check.line,
+        reason: `${check.textColorClass} is not a recognized color (custom theme color or unsupported arbitrary value) — skipped`,
+      });
+    }
   }
 
   return skips;

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -48,7 +48,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.4.0"
+    "tailwind-a11y": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- `text-gray-400/50`-style opacity modifiers were previously always treated as unresolvable and silently skipped, hiding real violations — nominally-dark text faded out by a low opacity value looked fine to the tool even when it renders too light to pass WCAG AA. Text-side opacity now composites against the already-resolved (opaque) background via a new `applyAlpha()` helper; background-side opacity (`bg-white/50` as the actual background) stays unresolved, since compositing it correctly would require knowing what's rendered *behind* it — out of scope for the same reason walking further up the ancestor chain already is.
- Deliberate scope decisions, documented in `packages/tailwind-a11y/CLAUDE.md`: an out-of-range percentage (`/150`) is **clamped** to 0–100 rather than rejected, matching how real browsers clamp out-of-range CSS alpha (rejecting it instead would hide a real violation behind what's essentially a typo); exactly 0% opacity (`/0`) is treated as unresolvable, like `text-transparent`, rather than an unconditional violation.
- `suggestContrastFix` now preserves the original opacity while searching for a passing shade, so a suggested fix for `text-gray-400/80` comes back as `text-gray-600/80`, not a bare shade with the opacity silently dropped.
- Independent review caught a real gap: the extraction regex (`COLOR_TOKEN` in `extractClasses.ts`) only kept the opacity suffix on scale-shade tokens (`text-gray-400/50`) — the semantic-word and arbitrary-hex shapes (`text-white/40`, `text-[#eee]/40`), arguably the *more* common real idiom, were silently dropped with no `--verbose` trace at all, before ever reaching the new opacity logic. Fixed by widening `COLOR_TOKEN` to accept the modifier on all three shapes.

## Test plan
- [x] `npm test` across all three packages — 185 tests passing (165 + 16 + 4)
- [x] `npm run build -w vscode-tailwind-a11y` — bundle rebuilds successfully
- [x] `npm run check:link` at root — workspace symlink resolution valid after all three version bumps
- [x] Every new numeric assertion (contrast ratios, suggested shades) verified by running the actual built code, not hand-computed — e.g. `text-gray-900/30` on `bg-white` → ratio ≈1.94, `text-white/40` on `bg-gray-800` → ratio ≈3.63, `text-gray-400/80` → suggested fix `text-gray-600/80` at ratio ≈4.53
- [x] Independent review fuzzed 225 (text, background) color combinations comparing old vs. new resolution order, and adversarial/malformed inputs (`text-gray-400/`, `text-gray-400//50`, double opacity suffixes) fed directly to the exported functions — none throw or silently misresolve