### PR TITLE
[v0.6.0] Fix two false negatives in the contrast and focus-indicator checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ fourth check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.1.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.6.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,10 +6648,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.5.0"
+        "tailwind-a11y": "^0.6.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6667,11 +6667,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.5.0"
+        "tailwind-a11y": "^0.6.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6681,7 +6681,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6705,10 +6705,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.5.0"
+        "tailwind-a11y": "^0.6.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.5.0"
+    "tailwind-a11y": "^0.6.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49171,7 +49171,7 @@ function getStaticClassName(attributes) {
 
 // ../tailwind-a11y/dist/parser/extractClasses.js
 var COLOR_TOKEN = /^\[(#[0-9a-fA-F]{3,8})\](\/\d{1,3})?$|^[a-z]+-\d{2,3}(\/\d{1,3})?$|^(white|black|transparent|current|inherit)(\/\d{1,3})?$/;
-var NON_COLOR_SCALE_NAMES = /* @__PURE__ */ new Set(["opacity"]);
+var NON_COLOR_SCALE_NAMES = /* @__PURE__ */ new Set(["opacity", "linear", "conic"]);
 function lastColorToken(className, prefix) {
   let found = null;
   for (const raw of className.split(/\s+/).filter(Boolean)) {
@@ -49824,12 +49824,48 @@ function extractFocusIndicatorChecks(code, filePath) {
 var REMOVAL_BASE = "outline-none";
 var DEGENERATE_BASES = /* @__PURE__ */ new Set(["outline-none", "ring-0", "border-0", "shadow-none", "bg-transparent"]);
 var MODIFIER_ONLY = /^(bg|border|ring)-opacity-\d{1,3}$|^(ring|outline)-offset-\d{1,3}$|^ring-inset$/;
+var NON_VISUAL_BASES = /* @__PURE__ */ new Set([
+  "bg-fixed",
+  "bg-local",
+  "bg-scroll",
+  "bg-repeat",
+  "bg-no-repeat",
+  "bg-repeat-x",
+  "bg-repeat-y",
+  "bg-repeat-round",
+  "bg-repeat-space",
+  "bg-auto",
+  "bg-cover",
+  "bg-contain",
+  "bg-clip-border",
+  "bg-clip-padding",
+  "bg-clip-content",
+  "bg-clip-text",
+  "bg-origin-border",
+  "bg-origin-padding",
+  "bg-origin-content",
+  "bg-none",
+  "bg-bottom",
+  "bg-center",
+  "bg-left",
+  "bg-left-bottom",
+  "bg-left-top",
+  "bg-right",
+  "bg-right-bottom",
+  "bg-right-top",
+  "bg-top",
+  "border-collapse",
+  "border-separate"
+]);
+var NON_VISUAL_PATTERN = /^bg-blend-/;
 function baseUtility(raw) {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
 function isReplacement(raw) {
   const base = baseUtility(raw);
   if (DEGENERATE_BASES.has(base) || MODIFIER_ONLY.test(base))
+    return false;
+  if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base))
     return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.5.0",
+    "tailwind-a11y": "^0.6.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -4,9 +4,9 @@
 added. Later, the GitHub repo itself was also renamed to `tailwind-a11y` and
 restructured as an npm workspaces monorepo — this package now lives at
 `packages/tailwind-a11y/` alongside `packages/eslint-plugin-tailwind-a11y/`.
-See the monorepo root `CLAUDE.md` for workspace-level conventions. Not yet
-published to npm, so all of this was free pre-launch churn with no
-back-compat concerns.)
+See the monorepo root `CLAUDE.md` for workspace-level conventions. Published
+to npm since 0.1.0, so changes here now carry real back-compat weight for
+published consumers, not free pre-launch churn.)
 
 ## What this is
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractClasses.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.test.ts
@@ -95,4 +95,15 @@ describe("extractChecks", () => {
       { file: "fake.tsx", line: 1, textColorClass: "text-[#eeeeee]/40", bgColorClass: "bg-gray-800", bgSource: "self" },
     ]);
   });
+
+  it.each(["bg-linear-45", "bg-conic-180"])(
+    "does not let a trailing gradient-angle utility %s overwrite the real color match (regression)",
+    (decoy) => {
+      const code = `const C = () => <p className="text-gray-400 bg-red-500 ${decoy}">x</p>;`;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toEqual([
+        { file: "fake.tsx", line: 1, textColorClass: "text-gray-400", bgColorClass: "bg-red-500", bgSource: "self" },
+      ]);
+    }
+  );
 });

--- a/packages/tailwind-a11y/src/parser/extractClasses.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.ts
@@ -25,8 +25,11 @@ const COLOR_TOKEN =
 // "word-number" shape as a color token but isn't one — without this
 // exclusion it can silently overwrite a real color match via the
 // last-token-wins rule below, making a real violation vanish (a false
-// negative, the worst failure mode for a linter).
-const NON_COLOR_SCALE_NAMES = new Set(["opacity"]);
+// negative, the worst failure mode for a linter). linear-{N}/conic-{N}
+// (Tailwind v4's bg-linear-45/bg-conic-180 gradient-angle utilities) are
+// the same failure mode: bg-linear-45 shares the word-number shape with
+// bg-red-500 and would otherwise mask it via last-token-wins.
+const NON_COLOR_SCALE_NAMES = new Set(["opacity", "linear", "conic"]);
 
 export function lastColorToken(className: string, prefix: "text" | "bg"): string | null {
   let found: string | null = null;

--- a/packages/tailwind-a11y/src/rules/checkContrast.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.test.ts
@@ -170,6 +170,18 @@ describe("checkContrast with a text-side opacity modifier", () => {
     expect(violations[0]).toMatchObject({ textClass: "text-white/40", bgClass: "bg-gray-800" });
     expect(violations[0].ratio).toBeCloseTo(3.63, 2);
   });
+
+  it("does not let a trailing gradient-angle utility mask a real violation end-to-end (regression)", () => {
+    // Caught in independent review: bg-linear-45 (Tailwind v4's gradient-angle
+    // utility) shared the word-number shape with a color token in
+    // extractClasses.ts's COLOR_TOKEN, so it won last-token-wins over the real
+    // bg-red-500 and the whole check silently vanished. Fixed by adding
+    // "linear"/"conic" to NON_COLOR_SCALE_NAMES.
+    const code = `const C = () => <p className="text-gray-400 bg-red-500 bg-linear-45">low contrast</p>;`;
+    const violations = checkContrast(extractChecks(code, "fake.tsx"));
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ textClass: "text-gray-400", bgClass: "bg-red-500" });
+  });
 });
 
 describe("checkContrast with a custom palette", () => {

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
@@ -69,6 +69,46 @@ describe("checkFocusIndicators", () => {
     expect(violations).toHaveLength(1);
   });
 
+  it.each([
+    "focus:bg-fixed",
+    "focus:bg-local",
+    "focus:bg-scroll",
+    "focus:bg-repeat",
+    "focus:bg-no-repeat",
+    "focus:bg-repeat-x",
+    "focus:bg-repeat-y",
+    "focus:bg-repeat-round",
+    "focus:bg-repeat-space",
+    "focus:bg-auto",
+    "focus:bg-cover",
+    "focus:bg-contain",
+    "focus:bg-clip-border",
+    "focus:bg-clip-padding",
+    "focus:bg-clip-content",
+    "focus:bg-clip-text",
+    "focus:bg-origin-border",
+    "focus:bg-origin-padding",
+    "focus:bg-origin-content",
+    "focus:bg-none",
+    "focus:bg-bottom",
+    "focus:bg-center",
+    "focus:bg-left",
+    "focus:bg-left-bottom",
+    "focus:bg-left-top",
+    "focus:bg-right",
+    "focus:bg-right-bottom",
+    "focus:bg-right-top",
+    "focus:bg-top",
+    "focus:border-collapse",
+    "focus:border-separate",
+    "focus:bg-blend-multiply",
+  ])("still flags when the only 'replacement' is a non-visual decoy %s (regression)", (decoy) => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", decoy] },
+    ]);
+    expect(violations).toHaveLength(1);
+  });
+
   it("still passes when a modifier accompanies a real replacement value", () => {
     const violations = checkFocusIndicators([
       {

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
@@ -24,6 +24,30 @@ const DEGENERATE_BASES = new Set(["outline-none", "ring-0", "border-0", "shadow-
 // pattern instead of enumerated.
 const MODIFIER_ONLY = /^(bg|border|ring)-opacity-\d{1,3}$|^(ring|outline)-offset-\d{1,3}$|^ring-inset$/;
 
+// Same failure mode again, one prefix-family level up: these utilities
+// share the bg-*/border-* prefix but control layout/rendering *behavior*
+// (attachment, repeat, size, clip, origin, position, table border mode),
+// not a visible color/width/style that could replace a removed outline.
+// Enumerated, not derived -- a future Tailwind utility sharing one of
+// these prefixes without providing visible styling could reintroduce this
+// gap, the same maintenance caveat as DEGENERATE_BASES/MODIFIER_ONLY above.
+const NON_VISUAL_BASES = new Set([
+  "bg-fixed", "bg-local", "bg-scroll",
+  "bg-repeat", "bg-no-repeat", "bg-repeat-x", "bg-repeat-y", "bg-repeat-round", "bg-repeat-space",
+  "bg-auto", "bg-cover", "bg-contain",
+  "bg-clip-border", "bg-clip-padding", "bg-clip-content", "bg-clip-text",
+  "bg-origin-border", "bg-origin-padding", "bg-origin-content",
+  "bg-none",
+  "bg-bottom", "bg-center", "bg-left", "bg-left-bottom", "bg-left-top",
+  "bg-right", "bg-right-bottom", "bg-right-top", "bg-top",
+  "border-collapse", "border-separate",
+]);
+
+// bg-blend-{mode} (e.g. bg-blend-multiply) sets a blend mode, not a color --
+// suffix-varying like MODIFIER_ONLY above, so pattern-matched instead of
+// enumerated.
+const NON_VISUAL_PATTERN = /^bg-blend-/;
+
 function baseUtility(raw: string): string {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -31,6 +55,7 @@ function baseUtility(raw: string): string {
 function isReplacement(raw: string): boolean {
   const base = baseUtility(raw);
   if (DEGENERATE_BASES.has(base) || MODIFIER_ONLY.test(base)) return false;
+  if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base)) return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }
 

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -48,7 +48,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.5.0"
+    "tailwind-a11y": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- `bg-linear-*`/`bg-conic-*` (Tailwind v4's gradient-angle utilities, e.g. `bg-linear-45`, `bg-conic-180`) share the same `word-NN` shape as a color token in `extractClasses.ts`'s `COLOR_TOKEN` regex. Since class extraction takes the last matching token, `bg-red-500 bg-linear-45` resolved to the gradient utility instead of the real color, failed to resolve, and silently dropped the contrast check for that element — a real WCAG violation reported as zero. Excluded via `NON_COLOR_SCALE_NAMES`, the same fix shape already used for `bg-opacity-50`.
- `checkFocusIndicator.ts`'s `isReplacement()` treated any `bg-*`/`border-*`/`ring-*`/`shadow-*`/`outline-*`-prefixed class as a valid replacement for a removed focus outline. Utilities sharing those prefixes — `bg-fixed`, `bg-repeat`, `bg-clip-text`, `border-collapse`, etc. — control layout/rendering behavior, not a visible color/width/style, so `focus:outline-none focus:bg-fixed` was incorrectly passing as compliant. Added a `NON_VISUAL_BASES` Set (31 entries) + `NON_VISUAL_PATTERN` (`bg-blend-*`), mirroring the existing `DEGENERATE_BASES`/`MODIFIER_ONLY` denylist.
- Also fixes stale docs: a false "not yet published to npm" claim in `packages/tailwind-a11y/CLAUDE.md`, a stale `^0.1.0` dependency-range example in the root `CLAUDE.md`, and two READMEs (`tailwind-a11y`, `vscode-tailwind-a11y`) missing the GitHub Action adapter from their related-packages sections.

## Versions
- `tailwind-a11y`: `0.5.1` → `0.6.0` (MINOR — both fixes increase the set of reported violations; a project relying on either decoy pattern can newly fail CI)
- `eslint-plugin-tailwind-a11y`: dependency range `^0.5.0` → `^0.6.0` (a MINOR engine bump falls outside the old caret range) and its own version synced to `0.6.0` to match the engine
- `vscode-tailwind-a11y`: dependency range bump to `^0.6.0` plus a version sync to `0.6.0` — it bundles the engine, so it needs a rebuild+republish regardless of its own source not changing
- `github-action-tailwind-a11y`: same as vscode (also a bundle) — dependency range bump to `^0.6.0`, version synced from `0.1.0` to `0.6.0`

## Test plan
- [x] `npm test --workspaces` — 236 tests passing (201 engine + 16 eslint + 4 vscode + 15 action)
- [x] `npm run build --workspaces` — all four packages build, including both committed bundles (`vscode-tailwind-a11y`, `github-action-tailwind-a11y`)
- [x] `npm run check:link` at root — workspace symlink resolution valid after all four version bumps
- [x] Regression tests for both fixes: `bg-linear-45`/`bg-conic-180` decoys in `extractClasses.test.ts` plus an end-to-end `checkContrast.test.ts` case confirming the previously-hidden violation is now reported; 31 non-visual-utility decoys (`bg-fixed`, `bg-repeat`, `border-collapse`, `bg-blend-multiply`, etc.) in `checkFocusIndicator.test.ts`