### PR TITLE
[v0.7.0] Add Tailwind v4 CSS @theme support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ fourth check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.6.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.7.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,10 +6648,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.6.0"
+        "tailwind-a11y": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6667,11 +6667,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.6.0"
+        "tailwind-a11y": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6681,7 +6681,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6705,10 +6705,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.6.0"
+        "tailwind-a11y": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -49,7 +49,8 @@ Exact scope and known limitations: [engine README](https://github.com/chamroro/t
 
 ## Custom theme
 
-A `tailwind.config.js`/`.cjs` in ESLint's cwd is auto-detected; point at a specific
+A `tailwind.config.js`/`.cjs` (Tailwind v3) or a CSS `@theme` file like
+`app/globals.css` (Tailwind v4) in ESLint's cwd is auto-detected; point at a specific
 file instead via `settings`:
 
 ```js

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.6.0"
+    "tailwind-a11y": "^0.7.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -28,7 +28,7 @@ found (configurable below).
 | Input | Default | Description |
 |---|---|---|
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
-| `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` for custom theme colors/spacing |
+| `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
 
 ```yaml

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49893,15 +49893,8 @@ function checkFocusIndicators(checks) {
 var import_node_fs = require("node:fs");
 var import_node_path = require("node:path");
 var import_node_module = require("node:module");
-var CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
-function findTailwindConfig(rootDir) {
-  for (const filename of CONFIG_FILENAMES) {
-    const candidate = (0, import_node_path.join)(rootDir, filename);
-    if ((0, import_node_fs.existsSync)(candidate))
-      return candidate;
-  }
-  return null;
-}
+
+// ../tailwind-a11y/dist/theme/themeValueParsers.js
 var SPACING_RE = /^-?[\d.]+(rem|px)$/;
 function parseSpacingValue(value) {
   if (typeof value !== "string")
@@ -49926,6 +49919,115 @@ function parseColorScale(value) {
     shades[shade] = shadeValue;
   }
   return Object.keys(shades).length > 0 ? shades : null;
+}
+
+// ../tailwind-a11y/dist/theme/parseThemeCss.js
+function maskStringLiterals(css) {
+  return css.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, (m) => " ".repeat(m.length));
+}
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+function extractThemeBlocks(css) {
+  const blocks = [];
+  const OPEN_RE = /@theme\b[^{]*\{/g;
+  let match;
+  while (match = OPEN_RE.exec(css)) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    for (; i < css.length && depth > 0; i++) {
+      if (css[i] === "{")
+        depth++;
+      else if (css[i] === "}")
+        depth--;
+    }
+    if (depth !== 0)
+      break;
+    blocks.push(css.slice(start, i - 1));
+    OPEN_RE.lastIndex = i;
+  }
+  return blocks;
+}
+function extractDeclarations(block) {
+  const decls = [];
+  for (const raw of block.split(";")) {
+    const trimmed = raw.trim();
+    if (!trimmed)
+      continue;
+    const colon = trimmed.indexOf(":");
+    if (colon === -1)
+      continue;
+    const prop = trimmed.slice(0, colon).trim();
+    if (!prop.startsWith("--"))
+      continue;
+    decls.push([prop, trimmed.slice(colon + 1).trim()]);
+  }
+  return decls;
+}
+var COLOR_PROP_RE = /^--color-(.+)-(\d+)$/;
+var SPACING_PROP_RE = /^--spacing-([\w-]+)$/;
+function parseThemeCss(cssText) {
+  const colorBuckets = {};
+  const spacingRaw = {};
+  for (const block of extractThemeBlocks(stripComments(maskStringLiterals(cssText)))) {
+    for (const [prop, value] of extractDeclarations(block)) {
+      const colorMatch = COLOR_PROP_RE.exec(prop);
+      if (colorMatch) {
+        const [, scale, shade] = colorMatch;
+        (colorBuckets[scale] ??= {})[shade] = value;
+        continue;
+      }
+      const spacingMatch = SPACING_PROP_RE.exec(prop);
+      if (spacingMatch)
+        spacingRaw[spacingMatch[1]] = value;
+    }
+  }
+  const result = {};
+  const colors = {};
+  for (const [scale, shades] of Object.entries(colorBuckets)) {
+    const parsed = parseColorScale(shades);
+    if (parsed)
+      colors[scale] = parsed;
+  }
+  if (Object.keys(colors).length > 0)
+    result.colors = colors;
+  const spacing = {};
+  for (const [token, value] of Object.entries(spacingRaw)) {
+    const px = parseSpacingValue(value);
+    if (px !== null)
+      spacing[token] = px;
+  }
+  if (Object.keys(spacing).length > 0)
+    result.spacing = spacing;
+  return result;
+}
+
+// ../tailwind-a11y/dist/theme/loadCustomTheme.js
+var CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
+function findTailwindConfig(rootDir) {
+  for (const filename of CONFIG_FILENAMES) {
+    const candidate = (0, import_node_path.join)(rootDir, filename);
+    if ((0, import_node_fs.existsSync)(candidate))
+      return candidate;
+  }
+  return null;
+}
+var CSS_THEME_CANDIDATES = [
+  "app/globals.css",
+  "src/app/globals.css",
+  "styles/globals.css",
+  "src/styles/globals.css",
+  "src/index.css",
+  "globals.css"
+];
+function findTailwindThemeCss(rootDir) {
+  for (const rel of CSS_THEME_CANDIDATES) {
+    const candidate = (0, import_node_path.join)(rootDir, rel);
+    if ((0, import_node_fs.existsSync)(candidate))
+      return candidate;
+  }
+  return null;
 }
 function bustRequireCache(require2, mod, seen) {
   if (seen.has(mod.id))
@@ -49970,6 +50072,13 @@ function loadCustomTheme(configPath) {
     return null;
   }
 }
+function loadThemeFromCssFile(cssPath) {
+  try {
+    return parseThemeCss((0, import_node_fs.readFileSync)(cssPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
 function mergePalette(base, extend) {
   if (!extend)
     return base;
@@ -49984,11 +50093,11 @@ function mergeSpacing(base, extend) {
 }
 function resolveTheme(opts) {
   const explicitPath = opts.configPath ?? null;
-  const configPath = explicitPath ?? (opts.rootDir ? findTailwindConfig(opts.rootDir) : null);
+  const configPath = explicitPath ?? (opts.rootDir ? findTailwindConfig(opts.rootDir) ?? findTailwindThemeCss(opts.rootDir) : null);
   if (!configPath) {
     return { palette: defaultPalette, spacing: spacingScale };
   }
-  const custom = loadCustomTheme(configPath);
+  const custom = configPath.endsWith(".css") ? loadThemeFromCssFile(configPath) : loadCustomTheme(configPath);
   if (custom === null) {
     return explicitPath ? {
       palette: defaultPalette,

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.6.0",
+    "tailwind-a11y": "^0.7.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -47,26 +47,47 @@ Tailwind-class-level sizing or focus-style analysis).
   `packages/vscode-tailwind-a11y` now exists as a third adapter over this
   engine (alongside the ESLint plugin) — it does not change this package's
   own scope, it just reuses `extractChecks`/`checkContrast` etc. directly.
-- **Custom `tailwind.config.js`/`.cjs` theme extension *is* implemented** (see
-  `theme/loadCustomTheme.ts`), but narrowly:
-  - Reads only `theme.extend.colors`/`theme.extend.spacing` — never a full
-    `theme.colors`/`theme.spacing` replacement.
-  - `.js`/`.cjs` only. No `.mjs`/`.ts` config files (no config-transpiling
-    dependency exists in this package, and none is being added just for
-    this). A `.js` config inside a `"type": "module"` project throws
-    `ERR_REQUIRE_ESM` on `require()` — caught, treated the same as "no
-    config found," not a crash.
-  - Tailwind v4's CSS-first `@theme` config is not read at all.
-  - No ancestor-directory search — only the given root dir is checked.
-    `--config` (CLI) / `settings["tailwind-a11y"].configPath` (ESLint) exist
-    as explicit overrides.
-  - Per color entry: only a plain object of hex-string shades is accepted
-    (validated with the existing `hexToRgb`). A flat string color
-    (`colors: { brand: '#3490dc' }`) or a `DEFAULT` key is skipped — no
-    class syntax (`bg-brand-DEFAULT` isn't real Tailwind) would ever resolve
-    to it.
-  - Per spacing entry: only `rem`/`px` string values are accepted (rem × 16,
-    matching `spacingScale.ts`'s own 16px-root assumption).
+- **Custom theme extension *is* implemented for both Tailwind v3 JS configs
+  and v4 CSS `@theme` configs** (see `theme/loadCustomTheme.ts` and
+  `theme/parseThemeCss.ts`), but narrowly:
+  - JS path: `tailwind.config.js`/`.cjs` only, reads only
+    `theme.extend.colors`/`theme.extend.spacing` — never a full
+    `theme.colors`/`theme.spacing` replacement. No `.mjs`/`.ts` config files
+    (no config-transpiling dependency exists in this package, and none is
+    being added just for this). A `.js` config inside a `"type": "module"`
+    project throws `ERR_REQUIRE_ESM` on `require()` — caught, treated the
+    same as "no config found," not a crash.
+  - CSS path: reads `--color-{name}-{shade}`/`--spacing-{token}` custom
+    properties out of `@theme { ... }` blocks (any modifier keyword, e.g.
+    `@theme inline { ... }`, is accepted — the declaration syntax inside is
+    identical). Auto-detection is a heuristic filename list (`app/globals.css`,
+    `src/app/globals.css`, `styles/globals.css`, `src/styles/globals.css`,
+    `src/index.css`, `globals.css` — most-specific first, since v4 has no
+    single conventional filename the way v3 has `tailwind.config.js`). Does
+    **not** follow `@import` statements to other CSS files — only `@theme`
+    blocks physically present in the loaded file are read. A bare
+    `--color-brand: #hex` (no shade suffix) or a bare `--spacing: <value>`
+    (the v4 global spacing multiplier) is skipped — same "no class syntax to
+    resolve it to" reasoning as the JS path's flat-string-color skip; the
+    multiplier specifically would need derived-value math `spacingScale.ts`'s
+    static token→px map doesn't do, a different feature.
+  - When both a JS config and an auto-detectable CSS file exist, the JS
+    config wins and the CSS file is never even checked — an existing
+    JS-config project gets zero change in resolved output.
+  - No ancestor-directory search — only the given root dir is checked (JS or
+    CSS). `--config` (CLI) / `settings["tailwind-a11y"].configPath` (ESLint) /
+    `INPUT_CONFIG` (GitHub Action) exist as explicit overrides, and accept
+    either a `.js`/`.cjs` or a `.css` path.
+  - Per color entry (both paths): only a plain hex-string value is accepted
+    (validated with the existing `hexToRgb`) — CSS `oklch()`/`rgb()`/`hsl()`/
+    `var()` etc. are skipped, same "not a hex value -- skip, don't guess"
+    precedent, even though Tailwind v4's own ecosystem leans OKLCH for brand
+    colors. A flat string color (`colors: { brand: '#3490dc' }`) or a
+    `DEFAULT` key is skipped on the JS path — no class syntax
+    (`bg-brand-DEFAULT` isn't real Tailwind) would ever resolve to it.
+  - Per spacing entry (both paths): only `rem`/`px` string values are
+    accepted (rem × 16, matching `spacingScale.ts`'s own 16px-root
+    assumption).
   - `semanticColors` (`white`/`black`/`transparent`/etc.) stays hardcoded,
     not re-themeable.
   - Running this tool now executes the target project's `tailwind.config.js`

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,15 +25,17 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                              # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"               # custom glob
 npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
-npx tailwind-a11y --config ./tw.config.cjs     # use a specific tailwind.config instead of auto-detecting
+npx tailwind-a11y --config ./tw.config.cjs     # use a specific config instead of auto-detecting
 npx tailwind-a11y --version                    # print the installed version
 npx tailwind-a11y --help                       # usage and all options
 ```
 
-Custom `theme.extend.colors`/`theme.extend.spacing` in a `tailwind.config.js`/`.cjs`
-found in the current directory (or passed via `--config`) are read automatically, so
-colors and spacing outside Tailwind's defaults resolve too — not just the built-in
-palette.
+Custom theme colors/spacing are read automatically, so colors and spacing outside
+Tailwind's defaults resolve too — not just the built-in palette. Both config formats
+are supported: `theme.extend.colors`/`theme.extend.spacing` in a Tailwind v3
+`tailwind.config.js`/`.cjs`, and `--color-*`/`--spacing-*` custom properties in a
+Tailwind v4 CSS `@theme { ... }` block (auto-detected from common paths like
+`app/globals.css`, or passed via `--config`).
 
 ```
 src/components/Card.tsx

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -19,9 +19,10 @@ Options:
   -v, --verbose      Also report what couldn't be checked, and why
   -V, --version      Print the version number
   -h, --help         Print this help message
-      --config <path>  Path to a tailwind.config.js/.cjs to read custom
-                        theme colors/spacing from (default: auto-detected
-                        in the current directory)
+      --config <path>  Path to a tailwind.config.js/.cjs (v3) or a CSS
+                        @theme file like app/globals.css (v4) to read
+                        custom theme colors/spacing from (default:
+                        auto-detected in the current directory)
 
 Examples:
   tailwind-a11y                    Scan **/*.{jsx,tsx} from the current directory

--- a/packages/tailwind-a11y/src/index.ts
+++ b/packages/tailwind-a11y/src/index.ts
@@ -9,9 +9,12 @@ export {
   resolveTheme,
   findTailwindConfig,
   loadCustomTheme,
+  findTailwindThemeCss,
+  loadThemeFromCssFile,
   mergePalette,
   mergeSpacing,
   type ResolvedTheme,
   type RawCustomTheme,
 } from "./theme/loadCustomTheme.js";
+export { parseThemeCss } from "./theme/parseThemeCss.js";
 export type { Palette, ColorScale } from "./theme/defaultPalette.js";

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   findTailwindConfig,
+  findTailwindThemeCss,
   loadCustomTheme,
+  loadThemeFromCssFile,
   mergePalette,
   mergeSpacing,
   resolveTheme,
@@ -41,6 +43,52 @@ describe("findTailwindConfig", () => {
 
   it("returns null when neither exists", () => {
     expect(findTailwindConfig(dir)).toBeNull();
+  });
+});
+
+describe("findTailwindThemeCss", () => {
+  it("finds app/globals.css", () => {
+    mkdirSync(join(dir, "app"), { recursive: true });
+    writeFileSync(join(dir, "app/globals.css"), "@theme {}");
+    expect(findTailwindThemeCss(dir)).toBe(join(dir, "app/globals.css"));
+  });
+
+  it("finds src/app/globals.css when app/globals.css is absent", () => {
+    mkdirSync(join(dir, "src/app"), { recursive: true });
+    writeFileSync(join(dir, "src/app/globals.css"), "@theme {}");
+    expect(findTailwindThemeCss(dir)).toBe(join(dir, "src/app/globals.css"));
+  });
+
+  it("finds bare globals.css only as a last resort", () => {
+    mkdirSync(join(dir, "app"), { recursive: true });
+    writeFileSync(join(dir, "app/globals.css"), "@theme {}");
+    writeFileSync(join(dir, "globals.css"), "@theme {}");
+    expect(findTailwindThemeCss(dir)).toBe(join(dir, "app/globals.css"));
+  });
+
+  it("returns null when no candidate exists", () => {
+    expect(findTailwindThemeCss(dir)).toBeNull();
+  });
+});
+
+describe("loadThemeFromCssFile", () => {
+  it("extracts @theme colors/spacing from a real file", () => {
+    const cssPath = join(dir, "globals.css");
+    writeFileSync(
+      cssPath,
+      `@theme {
+        --color-brand-500: #3490dc;
+        --spacing-18: 4.5rem;
+      }`
+    );
+    expect(loadThemeFromCssFile(cssPath)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+      spacing: { "18": 72 },
+    });
+  });
+
+  it("returns null for a missing file", () => {
+    expect(loadThemeFromCssFile(join(dir, "nope.css"))).toBeNull();
   });
 });
 
@@ -237,6 +285,53 @@ describe("resolveTheme", () => {
 
   it("stays silent (no configError) when auto-detection finds a broken config", () => {
     writeFileSync(join(dir, "tailwind.config.js"), "throw new Error('boom');");
+    expect(resolveTheme({ rootDir: dir }).configError).toBeUndefined();
+  });
+
+  it("auto-detects and merges a Tailwind v4 CSS @theme file when no JS config exists", () => {
+    mkdirSync(join(dir, "app"), { recursive: true });
+    writeFileSync(
+      join(dir, "app/globals.css"),
+      `@theme {
+        --color-brand-500: #3490dc;
+        --spacing-18: 4.5rem;
+      }`
+    );
+    const result = resolveTheme({ rootDir: dir });
+    expect(result.palette.brand).toEqual({ "500": "#3490dc" });
+    expect(result.spacing["18"]).toBe(72);
+    expect(result.configError).toBeUndefined();
+  });
+
+  it("prefers a JS config over an auto-detected CSS file when both exist", () => {
+    writeFileSync(
+      join(dir, "tailwind.config.js"),
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "#111111" } } } } };`
+    );
+    mkdirSync(join(dir, "app"), { recursive: true });
+    writeFileSync(join(dir, "app/globals.css"), `@theme { --color-brand-500: #222222; }`);
+    const result = resolveTheme({ rootDir: dir });
+    expect(result.palette.brand).toEqual({ "500": "#111111" });
+  });
+
+  it("uses an explicit .css configPath over auto-detection", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), `module.exports = {};`);
+    const explicitPath = join(dir, "custom-theme.css");
+    writeFileSync(explicitPath, `@theme { --color-brand-500: #abcdef; }`);
+    const result = resolveTheme({ rootDir: dir, configPath: explicitPath });
+    expect(result.palette.brand).toEqual({ "500": "#abcdef" });
+  });
+
+  it("sets configError when an explicit .css configPath fails to load", () => {
+    const explicitPath = join(dir, "does-not-exist.css");
+    const result = resolveTheme({ rootDir: dir, configPath: explicitPath });
+    expect(result.palette).toBe(defaultPalette);
+    expect(result.configError).toContain(explicitPath);
+  });
+
+  it("stays silent (no configError) when auto-detected CSS has no usable @theme content", () => {
+    mkdirSync(join(dir, "app"), { recursive: true });
+    writeFileSync(join(dir, "app/globals.css"), `body { color: red; }`);
     expect(resolveTheme({ rootDir: dir }).configError).toBeUndefined();
   });
 });

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
@@ -1,9 +1,10 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createRequire } from "node:module";
-import { hexToRgb } from "../contrast/luminance.js";
 import { defaultPalette } from "./defaultPalette.js";
 import { spacingScale } from "./spacingScale.js";
+import { parseColorScale, parseSpacingValue } from "./themeValueParsers.js";
+import { parseThemeCss } from "./parseThemeCss.js";
 import type { Palette } from "./defaultPalette.js";
 
 const CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
@@ -20,43 +21,44 @@ export function findTailwindConfig(rootDir: string): string | null {
   return null;
 }
 
+// Checked in priority order, in rootDir only (no recursive walk) -- v4 has no
+// single conventional filename the way v3 has tailwind.config.js, so this is
+// a heuristic covering common Next.js App Router / Pages Router / Vite React
+// conventions, most-specific first. `globals.css` is checked last since it's
+// the most generic name and the most likely to false-positive-match a file
+// that isn't actually the Tailwind entry point. --config (CLI) /
+// settings["tailwind-a11y"].configPath (ESLint) / INPUT_CONFIG (Action)
+// remain the escape hatch for anything else.
+const CSS_THEME_CANDIDATES = [
+  "app/globals.css",
+  "src/app/globals.css",
+  "styles/globals.css",
+  "src/styles/globals.css",
+  "src/index.css",
+  "globals.css",
+];
+
+export function findTailwindThemeCss(rootDir: string): string | null {
+  for (const rel of CSS_THEME_CANDIDATES) {
+    const candidate = join(rootDir, rel);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
 export interface RawCustomTheme {
   colors?: Palette;
   spacing?: Record<string, number>;
 }
 
-const SPACING_RE = /^-?[\d.]+(rem|px)$/;
-
-function parseSpacingValue(value: unknown): number | null {
-  if (typeof value !== "string") return null;
-  const match = SPACING_RE.exec(value);
-  if (!match) return null; // em/%/vw/bare number/function -- skip, don't guess
-  const num = parseFloat(value);
-  return match[1] === "rem" ? num * 16 : num; // matches spacingScale.ts's 16px-root assumption
-}
-
-// Only plain hex-shade objects are accepted (e.g. `brand: { 500: '#3490dc' }`).
-// A flat string color (`brand: '#3490dc'`) or a `DEFAULT` key is skipped
-// entirely -- there's no class syntax ("bg-brand-DEFAULT" isn't real Tailwind)
-// that would ever resolve to it, so partially supporting it would be dead code.
-function parseColorScale(value: unknown): Record<string, string> | null {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-  const shades: Record<string, string> = {};
-  for (const [shade, shadeValue] of Object.entries(value)) {
-    if (shade === "DEFAULT") continue; // no "bg-brand-DEFAULT" class syntax exists to resolve it
-    if (typeof shadeValue !== "string") continue;
-    if (hexToRgb(shadeValue) === null) continue; // not a hex value -- skip, don't guess
-    shades[shade] = shadeValue;
-  }
-  return Object.keys(shades).length > 0 ? shades : null;
-}
-
-// Loads a tailwind.config.js/.cjs and extracts only `theme.extend.colors` /
-// `theme.extend.spacing` -- v1 does not read a full `theme.colors`/`theme.spacing`
-// replacement, Tailwind v4's CSS-based `@theme` config, or .mjs/.ts configs (no
-// config-transpiling dependency exists in this package). `configPath` must be
-// an absolute path (require() resolves relative paths against this module's
-// own location, not the caller's cwd).
+// Loads a Tailwind v3-style tailwind.config.js/.cjs and extracts only
+// `theme.extend.colors`/`theme.extend.spacing` -- v1 does not read a full
+// `theme.colors`/`theme.spacing` replacement, or .mjs/.ts configs (no
+// config-transpiling dependency exists in this package). Tailwind v4's
+// CSS-based `@theme` config is a separate format entirely, handled by
+// loadThemeFromCssFile()/parseThemeCss() below, not by this function.
+// `configPath` must be an absolute path (require() resolves relative paths
+// against this module's own location, not the caller's cwd).
 //
 // Node's require() cache is busted before loading -- recursively, for the
 // config file *and* everything it required (e.g. a config that factors
@@ -117,6 +119,19 @@ export function loadCustomTheme(configPath: string): RawCustomTheme | null {
   }
 }
 
+// Loads a Tailwind v4 CSS file and extracts @theme colors/spacing via
+// parseThemeCss(). Returns null only when the file itself couldn't be read
+// (missing, permission error) -- a file that reads fine but has no @theme
+// block (or nothing recognized inside one) returns {}, same contract as
+// loadCustomTheme. `cssPath` must be an absolute path.
+export function loadThemeFromCssFile(cssPath: string): RawCustomTheme | null {
+  try {
+    return parseThemeCss(readFileSync(cssPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
 // New scale names are added wholesale; extending an existing scale merges
 // shade keys in without dropping the scale's other (default) shades.
 export function mergePalette(base: Palette, extend?: Palette): Palette {
@@ -145,16 +160,26 @@ export interface ResolvedTheme {
 // --config flag or ESLint settings) and failed to load -- auto-detected
 // absence stays silent, matching the "avoid confusing noise in an unrelated
 // linter run" precedent already in the ESLint plugin's index.ts. `rootDir`
-// and `configPath` (if given) must be absolute paths.
+// and `configPath` (if given) must be absolute paths. `configPath` may point
+// at either a .js/.cjs config or a .css file with an @theme block --
+// dispatched by extension below.
+//
+// Auto-detection tries the JS config first, CSS second: an existing project
+// with a tailwind.config.js gets zero change in resolved output even if it
+// also happens to have an unrelated @theme block (e.g. mid v3-to-v4
+// migration, or a leftover v3 config alongside a partially-adopted v4 CSS
+// file).
 export function resolveTheme(opts: { rootDir: string | null; configPath?: string | null }): ResolvedTheme {
   const explicitPath = opts.configPath ?? null;
-  const configPath = explicitPath ?? (opts.rootDir ? findTailwindConfig(opts.rootDir) : null);
+  const configPath =
+    explicitPath ??
+    (opts.rootDir ? (findTailwindConfig(opts.rootDir) ?? findTailwindThemeCss(opts.rootDir)) : null);
 
   if (!configPath) {
     return { palette: defaultPalette, spacing: spacingScale };
   }
 
-  const custom = loadCustomTheme(configPath);
+  const custom = configPath.endsWith(".css") ? loadThemeFromCssFile(configPath) : loadCustomTheme(configPath);
   if (custom === null) {
     return explicitPath
       ? {

--- a/packages/tailwind-a11y/src/theme/parseThemeCss.test.ts
+++ b/packages/tailwind-a11y/src/theme/parseThemeCss.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { parseThemeCss } from "./parseThemeCss.js";
+
+describe("parseThemeCss", () => {
+  it("extracts a color scale and a spacing token from a single @theme block", () => {
+    const css = `
+      @theme {
+        --color-brand-500: #3490dc;
+        --spacing-18: 4.5rem;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+      spacing: { "18": 72 },
+    });
+  });
+
+  it("returns {} for CSS with no @theme block at all", () => {
+    const css = `
+      body { color: red; }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("returns {} for an @theme block containing only unrelated custom properties", () => {
+    const css = `
+      @theme {
+        --font-sans: "Inter", sans-serif;
+        --radius-lg: 0.5rem;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("merges declarations across multiple @theme blocks in one file", () => {
+    const css = `
+      @theme {
+        --color-brand-500: #3490dc;
+      }
+      /* some other rule in between */
+      .foo { color: blue; }
+      @theme {
+        --color-brand-600: #2779bd;
+        --spacing-18: 4.5rem;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc", "600": "#2779bd" } },
+      spacing: { "18": 72 },
+    });
+  });
+
+  it("strips a comment before parsing, so a commented-out declaration never appears", () => {
+    const css = `
+      @theme {
+        /* --color-brand-500: #000000; */
+        --color-brand-500: #3490dc;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+    });
+  });
+
+  it("supports the @theme inline { ... } modifier variant", () => {
+    const css = `
+      @theme inline {
+        --color-brand-500: #3490dc;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+    });
+  });
+
+  it("skips a bare --color-brand declaration with no shade suffix", () => {
+    const css = `
+      @theme {
+        --color-brand: #3490dc;
+        --color-accent-500: #2779bd;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { accent: { "500": "#2779bd" } },
+    });
+  });
+
+  it.each(["oklch(0.6 0.2 250)", "rgb(52 144 220)", "var(--some-other-var)"])(
+    "skips a non-hex color value %s",
+    (value) => {
+      const css = `
+        @theme {
+          --color-brand-500: ${value};
+        }
+      `;
+      expect(parseThemeCss(css)).toEqual({});
+    }
+  );
+
+  it("skips a non-rem/px spacing value", () => {
+    const css = `
+      @theme {
+        --spacing-18: 50%;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("skips the bare --spacing global multiplier", () => {
+    const css = `
+      @theme {
+        --spacing: 0.25rem;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("resolves a hyphenated scale name (--color-hot-pink-500)", () => {
+    const css = `
+      @theme {
+        --color-hot-pink-500: #ff1493;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { "hot-pink": { "500": "#ff1493" } },
+    });
+  });
+
+  it("tolerates a missing trailing semicolon on the last declaration before }", () => {
+    const css = `
+      @theme {
+        --color-brand-500: #3490dc
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+    });
+  });
+
+  it("does not mistake @theme-looking text inside a CSS string literal for a real block (regression)", () => {
+    const css = `
+      .foo::before {
+        content: "@theme { --color-brand-500: #3490dc; }";
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("still extracts a real block when an unrelated string elsewhere contains braces/colons", () => {
+    const css = `
+      .foo::before {
+        content: "not a theme: { just text }";
+      }
+      @theme {
+        --color-brand-500: #3490dc;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+    });
+  });
+
+  it("returns {} for the whole file when an @theme block is missing its closing brace (regression: documents the real, safe-but-blunt fallback, not per-block recovery)", () => {
+    const css = `
+      @theme {
+        --color-brand-500: #3490dc;
+
+      @theme {
+        --color-accent-500: #2779bd;
+      }
+
+      .unrelated { color: red; }
+    `;
+    expect(parseThemeCss(css)).toEqual({});
+  });
+
+  it("extracts a combined realistic fixture end to end", () => {
+    const css = `
+      @import "tailwindcss";
+
+      @theme {
+        --color-brand-50: #eff6ff;
+        --color-brand-500: #3490dc;
+        --color-brand-900: #1e3a5f;
+        --color-accent-500: #2779bd;
+        --spacing-18: 4.5rem;
+        --spacing-112: 28rem;
+        --font-display: "Satoshi", sans-serif;
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: {
+        brand: { "50": "#eff6ff", "500": "#3490dc", "900": "#1e3a5f" },
+        accent: { "500": "#2779bd" },
+      },
+      spacing: { "18": 72, "112": 448 },
+    });
+  });
+});

--- a/packages/tailwind-a11y/src/theme/parseThemeCss.ts
+++ b/packages/tailwind-a11y/src/theme/parseThemeCss.ts
@@ -1,0 +1,135 @@
+import { parseColorScale, parseSpacingValue } from "./themeValueParsers.js";
+import type { RawCustomTheme } from "./loadCustomTheme.js";
+import type { Palette } from "./defaultPalette.js";
+
+// Run BEFORE comment-stripping/block-extraction so quoted string content
+// (e.g. a `content: "@theme { --color-brand-500: #3490dc; }"` value) can
+// never be mistaken for a real @theme block or accidentally throw off brace
+// counting -- without this, any valid CSS file containing that substring
+// for unrelated reasons (docs/marketing copy showcasing Tailwind v4 syntax,
+// for instance) would silently inject spurious palette/spacing entries.
+// Replaces each matched string (quotes included) with same-length spaces,
+// so it can't itself contain unmasked quotes/braces/`@theme` text, while
+// keeping offsets stable. An unterminated string (malformed CSS) just
+// doesn't match and is left as-is -- fail safe, don't guess.
+function maskStringLiterals(css: string): string {
+  return css.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, (m) => " ".repeat(m.length));
+}
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+// Matches `@theme {`, `@theme inline {`, `@theme static {`, and any other
+// modifier keyword Tailwind might add between `@theme` and the opening
+// brace -- the declaration syntax inside is identical regardless of
+// modifier, so no need to enumerate them. Brace-depth-counted (not a naive
+// first-`}` match) so an accidental nested `{` in a value can't truncate the
+// block early.
+//
+// An unclosed `@theme{` (malformed CSS -- missing a `}` somewhere) aborts
+// extraction for the rest of the file, not just that one block: brace
+// counting has no way to tell "a later, well-formed @theme block" apart
+// from "more content nested inside the still-open first block," so any
+// `{`/`}` pairs after the missing close (including a second, otherwise-valid
+// @theme block) get consumed as if they belonged to the first. The safe,
+// honest result is {} for the whole file rather than a guess at which
+// blocks were "real" -- same "skip, don't guess" precedent as everywhere
+// else in this parser, just at file granularity instead of block
+// granularity when recovery isn't possible.
+function extractThemeBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  const OPEN_RE = /@theme\b[^{]*\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = OPEN_RE.exec(css))) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    for (; i < css.length && depth > 0; i++) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+    }
+    if (depth !== 0) break;
+    blocks.push(css.slice(start, i - 1));
+    OPEN_RE.lastIndex = i;
+  }
+  return blocks;
+}
+
+// Split on `;` rather than a single greedy declaration regex, so a missing
+// trailing semicolon before `}` (valid CSS) doesn't drop the last
+// declaration.
+function extractDeclarations(block: string): Array<[string, string]> {
+  const decls: Array<[string, string]> = [];
+  for (const raw of block.split(";")) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const colon = trimmed.indexOf(":");
+    if (colon === -1) continue;
+    const prop = trimmed.slice(0, colon).trim();
+    if (!prop.startsWith("--")) continue;
+    decls.push([prop, trimmed.slice(colon + 1).trim()]);
+  }
+  return decls;
+}
+
+// Greedy .+ anchored on the *last* -\d+, so multi-hyphen scale names
+// (--color-hot-pink-500) resolve to scale "hot-pink", shade "500".
+const COLOR_PROP_RE = /^--color-(.+)-(\d+)$/;
+const SPACING_PROP_RE = /^--spacing-([\w-]+)$/;
+
+// Reads Tailwind v4's CSS-first `@theme { ... }` config -- extracts only
+// --color-{name}-{shade} and --spacing-{token} custom properties, running
+// each value through the exact same hex/rem-px acceptance rules as the JS
+// tailwind.config.js path (parseColorScale/parseSpacingValue from
+// themeValueParsers.ts), so no validation logic is duplicated between the
+// two config formats. A bare `--color-brand: #3490dc` (no shade suffix) is
+// skipped -- same "no class syntax to resolve it to" reasoning as the JS
+// path's flat-string-color skip. A bare `--spacing: 0.25rem` (Tailwind v4's
+// global spacing *multiplier*, which scales all arbitrary spacing
+// utilities) is also skipped -- spacingScale.ts is a static named-token to
+// px map, not a multiplier system; supporting the multiplier correctly
+// would mean reimplementing derived-value math, a different feature.
+// `@import`ed files are never followed -- only @theme blocks physically
+// present in the given CSS text are read.
+//
+// Never throws and never returns null -- unlike loadCustomTheme's
+// require()-based loading, this is tolerant scanning, not execution, so
+// there's no "syntax error" concept here. Worst case (no @theme block, or
+// nothing recognized inside one) returns {}, the same "loaded fine but
+// nothing to extend" contract loadCustomTheme uses.
+export function parseThemeCss(cssText: string): RawCustomTheme {
+  const colorBuckets: Record<string, Record<string, string>> = {};
+  const spacingRaw: Record<string, string> = {};
+
+  for (const block of extractThemeBlocks(stripComments(maskStringLiterals(cssText)))) {
+    for (const [prop, value] of extractDeclarations(block)) {
+      const colorMatch = COLOR_PROP_RE.exec(prop);
+      if (colorMatch) {
+        const [, scale, shade] = colorMatch;
+        (colorBuckets[scale] ??= {})[shade] = value;
+        continue;
+      }
+      const spacingMatch = SPACING_PROP_RE.exec(prop);
+      if (spacingMatch) spacingRaw[spacingMatch[1]] = value;
+    }
+  }
+
+  const result: RawCustomTheme = {};
+
+  const colors: Palette = {};
+  for (const [scale, shades] of Object.entries(colorBuckets)) {
+    const parsed = parseColorScale(shades);
+    if (parsed) colors[scale] = parsed;
+  }
+  if (Object.keys(colors).length > 0) result.colors = colors;
+
+  const spacing: Record<string, number> = {};
+  for (const [token, value] of Object.entries(spacingRaw)) {
+    const px = parseSpacingValue(value);
+    if (px !== null) spacing[token] = px;
+  }
+  if (Object.keys(spacing).length > 0) result.spacing = spacing;
+
+  return result;
+}

--- a/packages/tailwind-a11y/src/theme/themeValueParsers.ts
+++ b/packages/tailwind-a11y/src/theme/themeValueParsers.ts
@@ -1,0 +1,27 @@
+import { hexToRgb } from "../contrast/luminance.js";
+
+const SPACING_RE = /^-?[\d.]+(rem|px)$/;
+
+export function parseSpacingValue(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const match = SPACING_RE.exec(value);
+  if (!match) return null; // em/%/vw/bare number/function -- skip, don't guess
+  const num = parseFloat(value);
+  return match[1] === "rem" ? num * 16 : num; // matches spacingScale.ts's 16px-root assumption
+}
+
+// Only plain hex-shade objects are accepted (e.g. `brand: { 500: '#3490dc' }`).
+// A flat string color (`brand: '#3490dc'`) or a `DEFAULT` key is skipped
+// entirely -- there's no class syntax ("bg-brand-DEFAULT" isn't real Tailwind)
+// that would ever resolve to it, so partially supporting it would be dead code.
+export function parseColorScale(value: unknown): Record<string, string> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const shades: Record<string, string> = {};
+  for (const [shade, shadeValue] of Object.entries(value)) {
+    if (shade === "DEFAULT") continue; // no "bg-brand-DEFAULT" class syntax exists to resolve it
+    if (typeof shadeValue !== "string") continue;
+    if (hexToRgb(shadeValue) === null) continue; // not a hex value -- skip, don't guess
+    shades[shade] = shadeValue;
+  }
+  return Object.keys(shades).length > 0 ? shades : null;
+}

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -19,7 +19,8 @@ Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, a
 or [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
 instead — both treat the same findings as errors.
 
-A `tailwind.config.js`/`.cjs` in the open file's workspace folder is picked up
+A `tailwind.config.js`/`.cjs` (Tailwind v3) or a CSS `@theme` file like
+`app/globals.css` (Tailwind v4) in the open file's workspace folder is picked up
 automatically, so custom theme colors/spacing resolve the same way they do in the CLI
 and ESLint plugin.
 

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -48,7 +48,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.6.0"
+    "tailwind-a11y": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- `resolveTheme()` now reads Tailwind v4's CSS-first `@theme { --color-brand-500: #3490dc; --spacing-18: 4.5rem; }` config, in addition to the existing v3 `tailwind.config.js`/`.cjs` support. Motivated by a real gap found while scanning shadcn/ui (a v4 project): with no JS config to read, custom brand colors were silently treated as unresolvable, so contrast checks on them were skipped entirely rather than flagged.
- Auto-detected from a heuristic candidate list (`app/globals.css`, `src/app/globals.css`, `styles/globals.css`, `src/styles/globals.css`, `src/index.css`, `globals.css` — most-specific first, since v4 has no single conventional filename the way v3 has `tailwind.config.js`), or pointed at explicitly via `--config`/`settings.configPath`/`INPUT_CONFIG`, same as the JS path. When both a JS config and an auto-detectable CSS file exist, the JS config wins and the CSS file is never even checked — existing JS-config projects get zero change in resolved output.
- New `parseThemeCss.ts`: a pure, hand-rolled `@theme` block extractor (comment/string-strip, brace-balanced block extraction, `;`-split declaration parsing) — not a general CSS parser, no new dependency. Reuses the exact same hex-only/rem-px-only value acceptance rules as the JS path (`parseColorScale`/`parseSpacingValue`, extracted into a new `themeValueParsers.ts` leaf module so both paths share them without a circular import).
- Known scope cuts, documented in `packages/tailwind-a11y/CLAUDE.md`: no CSS color-function support (`oklch()`/`rgb()`/`hsl()`/`var()` etc. are skipped, hex-only — same "skip, don't guess" precedent as the JS path, even though v4's own ecosystem leans OKLCH); no `@import` resolution; a bare `--color-brand` (no shade) or bare `--spacing` (the v4 global multiplier) is skipped.
- Zero adapter-level changes — all four adapters only ever call `resolveTheme({rootDir, configPath})`, whose signature is unchanged.
- Independent review caught two real bugs in the CSS parser before this shipped: `@theme`-looking text inside an unrelated CSS string literal (e.g. a `content: "..."` value) was false-positively parsed as real theme data — fixed by masking string literals before block extraction; an unclosed `@theme{` block silently swallowed every well-formed `@theme` block later in the same file, contradicting its own code comment — fixed by correcting the comment to describe the actual (safe but file-wide, not per-block) fallback and locking it in with a regression test.

## Versions
- `tailwind-a11y`: `0.6.0` → `0.7.0` (MINOR — new capability, backward-compatible for existing JS-config projects)
- `eslint-plugin-tailwind-a11y`: dependency range `^0.6.0` → `^0.7.0` (mandatory, falls outside the old caret range) and its own version synced to `0.7.0`
- `vscode-tailwind-a11y`, `github-action-tailwind-a11y`: same reasoning — both bundle the engine at build time, so both need a version sync + rebuild to actually ship this regardless of their own source not changing; `github-action-tailwind-a11y`'s committed bundle is rebuilt accordingly
