### PR TITLE
[v0.8.0] Add config-path setting to the VS Code extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6705,7 +6705,7 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "tailwind-a11y": "^0.7.0"

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -78,6 +78,7 @@ When a case can't be resolved with confidence, it's skipped rather than guessed:
 
 - [`eslint-plugin-tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y) — same checks as ESLint rules
 - [`vscode-tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/vscode-tailwind-a11y) — same checks as live editor diagnostics
+- [`github-action-tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/github-action-tailwind-a11y) — same checks as inline PR annotations
 
 ## License
 

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -1,9 +1,10 @@
 # Tailwind a11y
 
 Live WCAG diagnostics for Tailwind CSS, in the editor — the same three checks as
-[`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
-and its [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y),
-powered by the same engine. Results never disagree between them — no detection logic is
+[`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y),
+its [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y),
+and its [GitHub Action](https://github.com/chamroro/tailwind-a11y/tree/main/packages/github-action-tailwind-a11y),
+all powered by the same engine. Results never disagree between them — no detection logic is
 reimplemented here.
 
 ## What it shows
@@ -22,7 +23,12 @@ instead — both treat the same findings as errors.
 A `tailwind.config.js`/`.cjs` (Tailwind v3) or a CSS `@theme` file like
 `app/globals.css` (Tailwind v4) in the open file's workspace folder is picked up
 automatically, so custom theme colors/spacing resolve the same way they do in the CLI
-and ESLint plugin.
+and ESLint plugin. Point at a specific file instead via the `tailwind-a11y.configPath`
+setting:
+
+```json
+{ "tailwind-a11y.configPath": "./app/globals.css" }
+```
 
 ## License
 

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -27,7 +27,19 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescriptreact"
   ],
-  "contributes": {},
+  "contributes": {
+    "configuration": {
+      "title": "Tailwind a11y",
+      "properties": {
+        "tailwind-a11y.configPath": {
+          "type": "string",
+          "default": "",
+          "scope": "resource",
+          "description": "Path to a tailwind.config.js/.cjs (v3) or a CSS @theme file like app/globals.css (v4), relative to the workspace folder. Overrides auto-detection."
+        }
+      }
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chamroro/tailwind-a11y.git",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -9,6 +9,7 @@ import {
   resolveTheme,
 } from "tailwind-a11y";
 import { formatViolation, type AnyViolation } from "./format.js";
+import { resolveConfigPathSetting } from "./resolveConfigSetting.js";
 
 const SUPPORTED_LANGUAGES = new Set(["javascriptreact", "typescriptreact"]);
 const DEBOUNCE_MS = 300;
@@ -71,9 +72,20 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
   // Resolved fresh on every call rather than cached -- fine performance-wise
   // since edits are already 300ms-debounced, and it's what makes an edit to
   // tailwind.config.js itself actually get picked up (relies on the engine's
-  // own require-cache busting in loadCustomTheme, not any caching here).
+  // own require-cache busting in loadCustomTheme, not any caching here). The
+  // same freshness covers the configPath setting too -- no
+  // onDidChangeConfiguration listener needed, the next debounced/save-
+  // triggered refresh() just picks up a changed setting on its own.
   const rootDir = vscode.workspace.getWorkspaceFolder(doc.uri)?.uri.fsPath ?? null;
-  const { palette, spacing } = resolveTheme({ rootDir });
+  const rawConfigPath = vscode.workspace.getConfiguration("tailwind-a11y", doc.uri).get<string>("configPath");
+  const configPath = resolveConfigPathSetting(rawConfigPath, rootDir);
+  const { palette, spacing, configError } = resolveTheme({ rootDir, configPath });
+  // configError only ever fires for an explicit configPath that failed to
+  // load -- auto-detection failure stays silent by design (see
+  // resolveTheme's own doc comment). A toast here would fire on every
+  // 300ms-debounced edit while the setting is broken; the Extension Host
+  // log is the same low-key channel the catch block below already uses.
+  if (configError) console.error(`tailwind-a11y: ${configError}`);
 
   const violations: AnyViolation[] = [
     ...checkContrast(extractChecks(text, file), palette),

--- a/packages/vscode-tailwind-a11y/src/resolveConfigSetting.test.ts
+++ b/packages/vscode-tailwind-a11y/src/resolveConfigSetting.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfigPathSetting } from "./resolveConfigSetting.js";
+
+describe("resolveConfigPathSetting", () => {
+  it("returns null when raw is undefined", () => {
+    expect(resolveConfigPathSetting(undefined, "/repo")).toBeNull();
+  });
+
+  it("returns null when raw is an empty string", () => {
+    expect(resolveConfigPathSetting("", "/repo")).toBeNull();
+  });
+
+  it("resolves a relative raw against rootDir", () => {
+    expect(resolveConfigPathSetting("./config/tailwind.config.cjs", "/repo")).toBe(
+      "/repo/config/tailwind.config.cjs"
+    );
+  });
+
+  it("resolves a relative raw pointing at a CSS file against rootDir", () => {
+    expect(resolveConfigPathSetting("app/globals.css", "/repo")).toBe("/repo/app/globals.css");
+  });
+
+  it("returns null for a relative raw when rootDir is null (nothing to resolve against)", () => {
+    expect(resolveConfigPathSetting("./tailwind.config.cjs", null)).toBeNull();
+  });
+
+  it("returns an already-absolute raw as-is even when rootDir is null", () => {
+    expect(resolveConfigPathSetting("/abs/tailwind.config.cjs", null)).toBe("/abs/tailwind.config.cjs");
+  });
+
+  it("returns an already-absolute raw unchanged even when rootDir is present", () => {
+    expect(resolveConfigPathSetting("/abs/tailwind.config.cjs", "/repo")).toBe("/abs/tailwind.config.cjs");
+  });
+});

--- a/packages/vscode-tailwind-a11y/src/resolveConfigSetting.ts
+++ b/packages/vscode-tailwind-a11y/src/resolveConfigSetting.ts
@@ -1,0 +1,19 @@
+import { isAbsolute, resolve } from "node:path";
+
+// Mirrors eslint-plugin-tailwind-a11y/src/theme.ts's resolveThemeForContext:
+// resolve the raw setting against rootDir if both are present. Kept in its
+// own module (no 'vscode' import) so it's testable under vitest, which can't
+// load the 'vscode' module outside the extension host -- same reason
+// format.ts is split out.
+//
+// path.resolve(rootDir, raw) already returns an already-absolute raw
+// unchanged regardless of rootDir, so an absolute setting value still works
+// even with no workspace folder open (single-file mode). A *relative* value
+// with no rootDir to resolve it against can't be turned into anything
+// meaningful, so it's dropped -- same "don't guess" precedent as the rest of
+// this engine's config resolution.
+export function resolveConfigPathSetting(raw: string | undefined, rootDir: string | null): string | null {
+  if (!raw) return null;
+  if (!rootDir) return isAbsolute(raw) ? raw : null;
+  return resolve(rootDir, raw);
+}


### PR DESCRIPTION
The CLI has `--config`, the ESLint plugin has `settings["tailwind-a11y"].configPath`, but the VS Code extension only ever auto-detected a config from the active document's workspace folder — no override when auto-detection isn't enough (a monorepo subpackage whose config lives elsewhere, a config outside the workspace root, etc).

New `tailwind-a11y.configPath` setting, resolved the same way the ESLint plugin's equivalent setting already is. Extracted the resolution into its own module with no `vscode` import, same reason `format.ts` is already split out — testable under vitest, which can't load `vscode` outside the extension host.

No engine/eslint-plugin/github-action changes — purely additive wiring inside the extension, so only `vscode-tailwind-a11y`'s own version bumps (`0.7.0` → `0.8.0`), independent of the engine.

Also restores two GitHub Action cross-links (engine README's Related section, this extension's own opening paragraph) that were written earlier this cycle but never actually landed on `main`.

## Test plan
- [x] `npm test --workspaces` — 272 tests passing (230 engine + 16 eslint + 11 vscode + 15 action)
- [x] `npm run build --workspaces` — all four packages build
- [x] `npm run check:link` at root
- [x] `git diff` confirms this only touches `vscode-tailwind-a11y` plus the two incidental README fixes — nothing in the engine, eslint-plugin, or github-action packages