### PR TITLE
[v0.8.0] Systematic decoy-pattern audit for the focus-indicator check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ fourth check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.7.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.8.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,10 +6648,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.7.0"
+        "tailwind-a11y": "^0.8.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6667,11 +6667,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.7.0"
+        "tailwind-a11y": "^0.8.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6681,7 +6681,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6705,10 +6705,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.7.0"
+        "tailwind-a11y": "^0.8.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.7.0"
+    "tailwind-a11y": "^0.8.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49822,7 +49822,15 @@ function extractFocusIndicatorChecks(code, filePath) {
 
 // ../tailwind-a11y/dist/rules/checkFocusIndicator.js
 var REMOVAL_BASE = "outline-none";
-var DEGENERATE_BASES = /* @__PURE__ */ new Set(["outline-none", "ring-0", "border-0", "shadow-none", "bg-transparent"]);
+var DEGENERATE_BASES = /* @__PURE__ */ new Set([
+  "outline-none",
+  "ring-0",
+  "border-0",
+  "shadow-none",
+  "bg-transparent",
+  "border-none",
+  "border-hidden"
+]);
 var MODIFIER_ONLY = /^(bg|border|ring)-opacity-\d{1,3}$|^(ring|outline)-offset-\d{1,3}$|^ring-inset$/;
 var NON_VISUAL_BASES = /* @__PURE__ */ new Set([
   "bg-fixed",
@@ -49857,7 +49865,16 @@ var NON_VISUAL_BASES = /* @__PURE__ */ new Set([
   "border-collapse",
   "border-separate"
 ]);
-var NON_VISUAL_PATTERN = /^bg-blend-/;
+var NON_VISUAL_PATTERN = /^bg-blend-|^border-spacing(-[xy])?-/;
+function isColorOnlyShadowOrRing(base) {
+  const shadowMatch = /^shadow-(.+)$/.exec(base);
+  if (shadowMatch && COLOR_TOKEN.test(shadowMatch[1]))
+    return true;
+  const ringMatch = /^ring-(.+)$/.exec(base);
+  if (ringMatch && COLOR_TOKEN.test(ringMatch[1]))
+    return true;
+  return false;
+}
 function baseUtility(raw) {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -49866,6 +49883,8 @@ function isReplacement(raw) {
   if (DEGENERATE_BASES.has(base) || MODIFIER_ONLY.test(base))
     return false;
   if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base))
+    return false;
+  if (isColorOnlyShadowOrRing(base))
     return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.7.0",
+    "tailwind-a11y": "^0.8.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -110,6 +110,31 @@ Tailwind-class-level sizing or focus-style analysis).
 - **Focus indicator: `focus:` and `focus-visible:` are merged** for the
   removal-vs-replacement comparison, since the standard accessible pattern
   (`focus:outline-none focus-visible:ring-2`) spans both variants.
+  - `isReplacement()`'s denylist was built via a systematic, one-time audit
+    of Tailwind's real utility surface (not memory) — every candidate below
+    was verified against a real Tailwind v4 build with computed styles
+    checked in a real browser, not reasoned about abstractly:
+    `border-none`/`border-hidden` (sets border-style but preflight resets
+    border-width to 0 on every element, so no border is ever drawn, same
+    failure mode as `border-0`); `border-spacing-*`/`-x-*`/`-y-*` (a
+    table-cell-gap property with zero effect on any non-table element);
+    `shadow-{color}`/`ring-{color}` alone, e.g. `shadow-red-500` (only sets
+    the `--tw-shadow-color`/`--tw-ring-color` CSS variable — the actual
+    `box-shadow` comes from a separate *size* utility like `shadow-lg`/
+    `ring-2` that references it, so the color alone renders nothing).
+    Confirmed *not* decoys, deliberately left alone: `outline-dashed`/
+    `-dotted`/`-solid`/`-double` alone (unlike border-width, preflight does
+    not reset `outline-width`, so the browser's default ~3px applies and
+    the outline is genuinely visible) and any border-*width* utility alone,
+    e.g. `border-t-4` (border-color defaults to `currentColor`, not
+    transparent, so a width-only utility is genuinely visible).
+  - Out of scope for this and future audits of this check: arbitrary
+    variants (`[&:hover]`-style), first-party plugin utilities
+    (`@tailwindcss/forms`, `@tailwindcss/typography` — not installed or
+    processed by this engine), container queries, and `divide-*` utilities
+    (they style child elements via a `> * + *` selector, not the element
+    carrying the `focus:` class itself, so they're structurally inapplicable
+    here regardless of visibility).
 - **Contrast: opacity modifiers (`text-gray-400/50`) are resolved on the
   *text* side only**, composited against the already-resolved (fully opaque)
   background — see `resolveTextColorWithOpacity()`/`applyAlpha()` in
@@ -195,6 +220,21 @@ the focus-indicator check (`focus:ring-0`/`border-0`/`shadow-none`/
 `bg-transparent` are explicitly denylisted as degenerate non-replacements).
 **Any new class-matching logic should ask: is there a same-shape decoy token
 that could mask a real violation?** — and add a regression test for it if so.
+
+This pattern was found reactively, one instance at a time, until a
+systematic one-time audit walked the focus-indicator check's entire risk
+surface against a real Tailwind v4 build (see the "Focus indicator" bullet
+above) and found five more in one pass: `border-none`/`border-hidden`,
+`border-spacing-*`, and color-only `shadow-*`/`ring-*`. That audit also
+confirmed the *other* two checks in this file have no equivalent risk: the
+touch-target check resolves against a closed, enumerated lookup table
+(`spacingScale`) rather than a permissive regex, so there's no same-shape-
+different-meaning token possible there; the contrast check's `bg-*`
+namespace was re-walked against every real `bg-*` utility category and
+turned up nothing beyond what was already fixed (`opacity`/`linear`/
+`conic`). If a new regex/token-matching check is ever added, prefer this
+same approach — verify against the real tool's actual output, not memory —
+over waiting for bugs to surface one at a time.
 
 ## Stack
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractClasses.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.ts
@@ -18,7 +18,11 @@ export interface ContrastCheck {
 // an extremely common real idiom, more so than the named-scale case, and
 // dropping it here would make the contrast checker's opacity support (see
 // rules/checkContrast.ts) silently inapplicable to the most common case.
-const COLOR_TOKEN =
+// Exported for reuse in checkFocusIndicator.ts, which needs the exact same
+// "does this suffix look like a color value" test to detect shadow-{color}/
+// ring-{color} decoys (see that file for why) -- one definition, not a
+// second copy that could silently drift out of sync.
+export const COLOR_TOKEN =
   /^\[(#[0-9a-fA-F]{3,8})\](\/\d{1,3})?$|^[a-z]+-\d{2,3}(\/\d{1,3})?$|^(white|black|transparent|current|inherit)(\/\d{1,3})?$/;
 
 // opacity-{N} (e.g. bg-opacity-50, text-opacity-50) matches the same

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
@@ -109,6 +109,58 @@ describe("checkFocusIndicators", () => {
     expect(violations).toHaveLength(1);
   });
 
+  it.each([
+    "focus:border-none",
+    "focus:border-hidden",
+    "focus:border-spacing-8",
+    "focus:border-spacing-x-4",
+    "focus:border-spacing-y-2",
+  ])("still flags when the only 'replacement' is a table/border-style decoy %s (regression)", (decoy) => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", decoy] },
+    ]);
+    expect(violations).toHaveLength(1);
+  });
+
+  it.each([
+    "focus:shadow-red-500",
+    "focus:shadow-black",
+    "focus:shadow-[#fff]",
+    "focus:ring-red-500",
+    "focus:ring-blue-400/50",
+  ])("still flags when the only 'replacement' is a color-only shadow/ring decoy %s (regression)", (decoy) => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", decoy] },
+    ]);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("still passes when a shadow/ring color is paired with a real size utility", () => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", "focus:shadow-lg", "focus:shadow-red-500"] },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it.each([
+    "focus:outline-dashed",
+    "focus:outline-dotted",
+    "focus:outline-solid",
+    "focus:outline-double",
+  ])("passes for %s alone (confirmed real: browser default outline-width is not reset by preflight)", (real) => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", real] },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("passes for a border-width-only utility alone (confirmed real: border-color defaults to currentColor)", () => {
+    const violations = checkFocusIndicators([
+      { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", "focus:border-t-4"] },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
   it("still passes when a modifier accompanies a real replacement value", () => {
     const violations = checkFocusIndicators([
       {

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
@@ -1,4 +1,5 @@
 import type { FocusIndicatorCheck } from "../parser/extractFocusIndicators.js";
+import { COLOR_TOKEN } from "../parser/extractClasses.js";
 
 export interface FocusIndicatorViolation {
   type: "focus-indicator";
@@ -13,8 +14,15 @@ const REMOVAL_BASE = "outline-none";
 // Utilities that match the "replacement" shape but are semantically no-ops —
 // the same failure mode as bg-opacity-50 masking a real color match: a
 // same-prefix decoy that would silently hide a real violation if we only
-// checked the prefix.
-const DEGENERATE_BASES = new Set(["outline-none", "ring-0", "border-0", "shadow-none", "bg-transparent"]);
+// checked the prefix. border-none/border-hidden only set border-style, not
+// border-width -- verified against a real Tailwind v4 build that preflight
+// resets every element to `border: 0 solid`, so border-width stays 0
+// regardless of style and no border is ever drawn, same failure mode as
+// border-0.
+const DEGENERATE_BASES = new Set([
+  "outline-none", "ring-0", "border-0", "shadow-none", "bg-transparent",
+  "border-none", "border-hidden",
+]);
 
 // Modifier-only utilities (opacity/offset/inset) don't set a concrete value
 // on their own — e.g. bg-opacity-50 with no bg-* color, or ring-offset-4
@@ -45,8 +53,31 @@ const NON_VISUAL_BASES = new Set([
 
 // bg-blend-{mode} (e.g. bg-blend-multiply) sets a blend mode, not a color --
 // suffix-varying like MODIFIER_ONLY above, so pattern-matched instead of
-// enumerated.
-const NON_VISUAL_PATTERN = /^bg-blend-/;
+// enumerated. border-spacing-*/-x-*/-y-* sets the CSS border-spacing
+// property, which only affects the gap between <table> cells -- verified
+// against a real Tailwind v4 build that it has zero visual effect on any
+// non-table element (the only elements this check ever fires on), even
+// with a real numeric value applied.
+const NON_VISUAL_PATTERN = /^bg-blend-|^border-spacing(-[xy])?-/;
+
+// shadow-{color}/ring-{color} alone (e.g. shadow-red-500, ring-blue-400/50,
+// an arbitrary hex) only sets the --tw-shadow-color/--tw-ring-color CSS
+// variable -- the actual box-shadow property is set by a separate *size*
+// utility (shadow-lg, ring-2, etc.) that references that variable. Verified
+// against a real Tailwind v4 build: shadow-red-500 alone computes to
+// `box-shadow: none`; shadow-lg shadow-red-500 together produce a real,
+// colored shadow. Same underlying mechanism as MODIFIER_ONLY's opacity/
+// offset cases above, but shaped like a color token rather than a fixed
+// suffix, so it reuses COLOR_TOKEN (the exact same "is this a color value"
+// test extractClasses.ts uses) instead of a third, drifting definition of
+// what a color looks like.
+function isColorOnlyShadowOrRing(base: string): boolean {
+  const shadowMatch = /^shadow-(.+)$/.exec(base);
+  if (shadowMatch && COLOR_TOKEN.test(shadowMatch[1])) return true;
+  const ringMatch = /^ring-(.+)$/.exec(base);
+  if (ringMatch && COLOR_TOKEN.test(ringMatch[1])) return true;
+  return false;
+}
 
 function baseUtility(raw: string): string {
   return raw.slice(raw.lastIndexOf(":") + 1);
@@ -56,6 +87,7 @@ function isReplacement(raw: string): boolean {
   const base = baseUtility(raw);
   if (DEGENERATE_BASES.has(base) || MODIFIER_ONLY.test(base)) return false;
   if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base)) return false;
+  if (isColorOnlyShadowOrRing(base)) return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }
 

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -60,7 +60,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.7.0"
+    "tailwind-a11y": "^0.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Nine real bugs across this project's history have shared one root cause: a Tailwind utility class matches the *shape* something is looking for without matching its *meaning*. Instead of continuing to find these reactively one at a time, this is a one-time systematic audit — installed a real Tailwind v4.3.3 build, compiled real CSS, checked real computed styles in Chrome for every candidate, rather than reasoning from memory.

## Five confirmed decoys fixed

- `border-none`/`border-hidden` — only sets `border-style`; Tailwind v4's preflight resets `border-width` to `0` on every element, so no border is ever drawn regardless of style. Same failure mode as the already-covered `border-0`.
- `border-spacing-*`/`-x-*`/`-y-*` — a table-cell-gap CSS property with zero visual effect on any non-table element (the only elements this check ever fires on).
- `shadow-{color}` alone (e.g. `shadow-red-500`) — only sets the `--tw-shadow-color` variable; the actual `box-shadow` comes from a size utility (`shadow-lg`, etc.) that references it.
- `ring-{color}` alone — identical mechanism.

The shadow/ring-color check reuses `extractClasses.ts`'s existing `COLOR_TOKEN` regex (now exported) instead of a second, drifting copy of "what does a color value look like."

## Two suspected decoys confirmed NOT bugs

Left unchanged, with regression tests locking in the current correct behavior: `outline-dashed`/`-dotted`/`-solid`/`-double` alone (preflight doesn't reset `outline-width`, so the browser's ~3px default makes it genuinely visible), and border-width-only utilities like `border-t-4` (border-color defaults to `currentColor`, so it's genuinely visible).

Also re-walked the contrast check's `bg-*` namespace (no new gaps beyond the already-fixed opacity/linear/conic) and confirmed the touch-target check has no analogous risk surface at all — it resolves against a closed, enumerated lookup table, not a permissive regex.

## Versions
- `tailwind-a11y`: `0.7.0` → `0.8.0` (MINOR — detection fix that increases reported violations)
- `eslint-plugin-tailwind-a11y`, `github-action-tailwind-a11y`: sync to `0.8.0` exactly, matching the engine
- `vscode-tailwind-a11y`: already published `0.8.0` for an unrelated, already-merged feature (the config-path setting), so it can't reuse that number — bumps to `0.9.0` instead

## Test plan
- [x] `npm test --workspaces` — 288 tests passing (246 engine + 16 eslint + 11 vscode + 15 action)
- [x] `npm run build --workspaces` — all four packages build
- [x] `npm run check:link` at root
- [x] Bundle staleness check (`git diff --exit-code` on the committed Action `dist/`) passes clean after rebuild
- [x] All six empirical Tailwind-behavior claims independently re-verified in a second pass — reinstalled Tailwind fresh, recompiled, rechecked real computed styles in Chrome from scratch, not just re-reading the same reasoning