### PR TITLE
Add touch-target strict mode: WCAG 2.5.5 AAA (44px), opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ fourth check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.8.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.9.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
       report annotations without failing.
     required: false
     default: "true"
+  strict:
+    description: >-
+      Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default
+      2.5.8 (AA, 24x24px).
+    required: false
+    default: "false"
 
 runs:
   using: "node24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,10 +6648,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.8.0"
+        "tailwind-a11y": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6667,11 +6667,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.8.0"
+        "tailwind-a11y": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6681,7 +6681,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6705,10 +6705,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.8.0"
+        "tailwind-a11y": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -42,7 +42,7 @@ export default [
 | Rule | WCAG | Detects |
 |---|---|---|
 | `contrast` | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — suggests the nearest passing shade |
-| `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px |
+| `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
@@ -57,6 +57,23 @@ file instead via `settings`:
 export default [
   ...tailwindA11y.configs.recommended,
   { settings: { "tailwind-a11y": { configPath: "./tailwind.config.cjs" } } },
+];
+```
+
+## Stricter touch targets
+
+`touch-target` defaults to WCAG 2.5.8 (AA, 24×24px). Pass `{ strict: true }`
+as a rule option to enforce 2.5.5 (AAA, 44×44px) instead:
+
+```js
+export default [
+  {
+    files: ["**/*.jsx", "**/*.tsx"],
+    plugins: { "tailwind-a11y": tailwindA11y },
+    rules: {
+      "tailwind-a11y/touch-target": ["warn", { strict: true }],
+    },
+  },
 ];
 ```
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.8.0"
+    "tailwind-a11y": "^0.9.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.test.ts
@@ -40,6 +40,17 @@ ruleTester.run("touch-target", rule, {
       filename: "Small.jsx",
       code: `export const Small = () => <button className="w-5.5 h-5.5" onClick={() => {}}>x</button>;`,
     },
+    {
+      name: "40x40 passes by default (strict option not set)",
+      filename: "Ok40.jsx",
+      code: `export const Ok = () => <button className="w-10 h-10" onClick={() => {}}>x</button>;`,
+    },
+    {
+      name: "exactly 44x44 passes under strict (minimum is inclusive, same as the default 24px)",
+      filename: "Ok44.jsx",
+      code: `export const Ok = () => <button className="w-11 h-11" onClick={() => {}}>x</button>;`,
+      options: [{ strict: true }],
+    },
   ],
   invalid: [
     {
@@ -74,6 +85,19 @@ ruleTester.run("touch-target", rule, {
       errors: [
         {
           message: "<button> is 16×16px (w-4 h-4) — WCAG 2.5.8 requires >= 24×24px",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      name: "40x40 fails under strict, reporting WCAG 2.5.5 and the 44px threshold",
+      filename: "Strict40.jsx",
+      code: `export const B = () => <button className="w-10 h-10" onClick={() => {}}>x</button>;`,
+      options: [{ strict: true }],
+      errors: [
+        {
+          message: "<button> is 40×40px (w-10 h-10) — WCAG 2.5.5 requires >= 44×44px",
           line: 1,
           column: 1,
         },

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/touch-target.ts
@@ -11,10 +11,15 @@ const rule: Rule.RuleModule = {
       recommended: true,
       url: "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#touch-target",
     },
-    schema: [],
+    // First rule in this codebase to need a non-empty schema -- configPath
+    // deliberately lives in context.settings instead of options (see
+    // theme.ts), since it's cross-cutting across all three rules. strict is
+    // touch-target-specific, so it belongs on this rule's own options, not
+    // bundled into that shared object.
+    schema: [{ type: "object", properties: { strict: { type: "boolean" } }, additionalProperties: false }],
     messages: {
       touchTarget:
-        "<{{tagName}}> is {{widthPx}}×{{heightPx}}px ({{widthClass}} {{heightClass}}) — WCAG 2.5.8 requires >= 24×24px",
+        "<{{tagName}}> is {{widthPx}}×{{heightPx}}px ({{widthClass}} {{heightClass}}) — WCAG {{wcagSC}} requires >= {{requiredPx}}×{{requiredPx}}px",
     },
   },
 
@@ -22,8 +27,10 @@ const rule: Rule.RuleModule = {
     return {
       Program() {
         const { spacing } = resolveThemeForContext(context);
+        const strict = (context.options[0] as { strict?: boolean } | undefined)?.strict ?? false;
         const violations = checkTouchTargets(
-          extractTouchTargetChecks(context.sourceCode.getText(), context.filename, spacing)
+          extractTouchTargetChecks(context.sourceCode.getText(), context.filename, spacing),
+          strict
         );
 
         for (const v of violations) {
@@ -36,6 +43,8 @@ const rule: Rule.RuleModule = {
               heightPx: v.heightPx,
               widthClass: v.widthClass,
               heightClass: v.heightClass,
+              requiredPx: v.required,
+              wcagSC: v.level === "AAA" ? "2.5.5" : "2.5.8",
             },
           });
         }

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -30,6 +30,7 @@ found (configurable below).
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
 | `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
+| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px) |
 
 ```yaml
 - uses: chamroro/tailwind-a11y@v0
@@ -39,15 +40,16 @@ found (configurable below).
       app/**/*.jsx
     config: ./tailwind.config.cjs
     fail-on-violations: "false"
+    strict: "true"
 ```
 
 ## Notes
 
 - `node_modules`, `dist`, `build`, and `.git` directories are always excluded
   from scanning.
-- GitHub renders roughly 10 inline annotations per step — beyond that, the
-  full list is still in the job log and the job summary table, and the exit
-  code always reflects every violation found.
+- GitHub renders roughly 10 inline annotations per type per step (and ~50 per
+  job) — beyond that, the full list is still in the job log and the job
+  summary table, and the exit code always reflects every violation found.
 - Pin a commit SHA instead of `@v0` if you want fully immutable behavior:
   `uses: chamroro/tailwind-a11y@<sha>`.
 - Checks and known limitations are the engine's:

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49780,8 +49780,11 @@ function extractTouchTargetChecks(code, filePath, spacing = spacingScale) {
 
 // ../tailwind-a11y/dist/rules/checkTouchTarget.js
 var MIN_TARGET_PX = 24;
-function checkTouchTargets(checks) {
-  return checks.filter((c) => c.widthPx < MIN_TARGET_PX || c.heightPx < MIN_TARGET_PX).map((c) => ({ type: "touch-target", ...c }));
+var MIN_TARGET_PX_STRICT = 44;
+function checkTouchTargets(checks, strict = false) {
+  const required = strict ? MIN_TARGET_PX_STRICT : MIN_TARGET_PX;
+  const level = strict ? "AAA" : "AA";
+  return checks.filter((c) => c.widthPx < required || c.heightPx < required).map((c) => ({ type: "touch-target", ...c, required, level }));
 }
 
 // ../tailwind-a11y/dist/parser/extractFocusIndicators.js
@@ -50135,12 +50138,17 @@ function parseInputs(env) {
   const patternsRaw = env["INPUT_PATTERNS"]?.trim();
   const configRaw = env["INPUT_CONFIG"]?.trim();
   const failRaw = env["INPUT_FAIL-ON-VIOLATIONS"]?.trim().toLowerCase();
+  const strictRaw = env["INPUT_STRICT"]?.trim().toLowerCase();
   return {
     patterns: patternsRaw ? patternsRaw.split(/\s+/).filter(Boolean) : ["**/*.{jsx,tsx}"],
     config: configRaw || null,
     // Anything other than an explicit "false" keeps the safe default of
     // failing the job on violations.
-    failOnViolations: failRaw !== "false"
+    failOnViolations: failRaw !== "false",
+    // Opposite direction from failOnViolations above: strict is opt-in, so
+    // anything other than an explicit "true" keeps the safe default of the
+    // existing WCAG 2.5.8 (AA) 24px threshold.
+    strict: strictRaw === "true"
   };
 }
 
@@ -50158,8 +50166,10 @@ function formatViolation(v) {
       const base = `${v.textClass} on ${v.bgClass} \u2014 ratio ${v.ratio.toFixed(2)}, needs ${v.required} (${v.level})`;
       return v.suggestion ? `${base}; try ${v.suggestion} (${v.suggestedRatio.toFixed(2)})` : base;
     }
-    case "touch-target":
-      return `<${v.tagName}> is ${v.widthPx}\xD7${v.heightPx}px (${v.widthClass} ${v.heightClass}) \u2014 WCAG 2.5.8 requires >= 24\xD724px`;
+    case "touch-target": {
+      const sc = v.level === "AAA" ? "2.5.5" : "2.5.8";
+      return `<${v.tagName}> is ${v.widthPx}\xD7${v.heightPx}px (${v.widthClass} ${v.heightClass}) \u2014 WCAG ${sc} requires >= ${v.required}\xD7${v.required}px`;
+    }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
   }
@@ -50182,7 +50192,7 @@ function groupByFile(violations) {
   return byFile;
 }
 async function main() {
-  const { patterns, config, failOnViolations } = parseInputs(process.env);
+  const { patterns, config, failOnViolations, strict } = parseInputs(process.env);
   const cwd = process.cwd();
   const { palette, spacing, configError } = resolveTheme({
     rootDir: cwd,
@@ -50203,7 +50213,7 @@ async function main() {
       const code = (0, import_node_fs2.readFileSync)(absPath, "utf8");
       violations.push(
         ...checkContrast(extractChecks(code, file), palette),
-        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing)),
+        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
       );
     } catch (err) {

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.8.0",
+    "tailwind-a11y": "^0.9.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/src/annotations.test.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.test.ts
@@ -42,8 +42,26 @@ describe("formatViolation", () => {
       heightClass: "h-4",
       widthPx: 16,
       heightPx: 16,
+      required: 24,
+      level: "AA",
     });
     expect(message).toBe("<button> is 16×16px (w-4 h-4) — WCAG 2.5.8 requires >= 24×24px");
+  });
+
+  it("formats a strict-mode touch-target violation with WCAG 2.5.5 and the 44px threshold", () => {
+    const message = formatViolation({
+      type: "touch-target",
+      file: "src/IconButton.tsx",
+      line: 5,
+      tagName: "button",
+      widthClass: "w-10",
+      heightClass: "h-10",
+      widthPx: 40,
+      heightPx: 40,
+      required: 44,
+      level: "AAA",
+    });
+    expect(message).toBe("<button> is 40×40px (w-10 h-10) — WCAG 2.5.5 requires >= 44×44px");
   });
 
   it("formats a focus-indicator violation", () => {
@@ -71,6 +89,8 @@ describe("toAnnotationCommand", () => {
       heightClass: "h-4",
       widthPx: 16,
       heightPx: 16,
+      required: 24,
+      level: "AA",
     });
     expect(command).toBe(
       "::error file=src/IconButton.tsx,line=5,title=tailwind-a11y::<button> is 16×16px (w-4 h-4) — WCAG 2.5.8 requires >= 24×24px"

--- a/packages/github-action-tailwind-a11y/src/annotations.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.ts
@@ -29,8 +29,10 @@ export function formatViolation(v: AnyViolation): string {
       const base = `${v.textClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (${v.level})`;
       return v.suggestion ? `${base}; try ${v.suggestion} (${v.suggestedRatio!.toFixed(2)})` : base;
     }
-    case "touch-target":
-      return `<${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG 2.5.8 requires >= 24×24px`;
+    case "touch-target": {
+      const sc = v.level === "AAA" ? "2.5.5" : "2.5.8";
+      return `<${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG ${sc} requires >= ${v.required}×${v.required}px`;
+    }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
   }

--- a/packages/github-action-tailwind-a11y/src/inputs.test.ts
+++ b/packages/github-action-tailwind-a11y/src/inputs.test.ts
@@ -7,6 +7,7 @@ describe("parseInputs", () => {
       patterns: ["**/*.{jsx,tsx}"],
       config: null,
       failOnViolations: true,
+      strict: false,
     });
   });
 
@@ -42,5 +43,22 @@ describe("parseInputs", () => {
     expect(parseInputs({ INPUT_CONFIG: "./tailwind.config.cjs" }).config).toBe("./tailwind.config.cjs");
     expect(parseInputs({ INPUT_CONFIG: "" }).config).toBeNull();
     expect(parseInputs({ INPUT_CONFIG: "  " }).config).toBeNull();
+  });
+
+  it("reads the strict input, opt-in (opposite default direction from fail-on-violations)", () => {
+    expect(parseInputs({ INPUT_STRICT: "true" }).strict).toBe(true);
+    expect(parseInputs({ INPUT_STRICT: "false" }).strict).toBe(false);
+    expect(parseInputs({}).strict).toBe(false);
+  });
+
+  it("treats anything other than an explicit 'true' as false for strict (safe default)", () => {
+    expect(parseInputs({ INPUT_STRICT: "yes" }).strict).toBe(false);
+    expect(parseInputs({ INPUT_STRICT: "1" }).strict).toBe(false);
+    expect(parseInputs({ INPUT_STRICT: "" }).strict).toBe(false);
+  });
+
+  it("is case-insensitive for strict", () => {
+    expect(parseInputs({ INPUT_STRICT: "TRUE" }).strict).toBe(true);
+    expect(parseInputs({ INPUT_STRICT: "True" }).strict).toBe(true);
   });
 });

--- a/packages/github-action-tailwind-a11y/src/inputs.ts
+++ b/packages/github-action-tailwind-a11y/src/inputs.ts
@@ -2,6 +2,7 @@ export interface ActionInputs {
   patterns: string[];
   config: string | null;
   failOnViolations: boolean;
+  strict: boolean;
 }
 
 // The Actions runner exposes inputs as INPUT_<NAME> env vars, uppercased but
@@ -16,6 +17,7 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
   const patternsRaw = env["INPUT_PATTERNS"]?.trim();
   const configRaw = env["INPUT_CONFIG"]?.trim();
   const failRaw = env["INPUT_FAIL-ON-VIOLATIONS"]?.trim().toLowerCase();
+  const strictRaw = env["INPUT_STRICT"]?.trim().toLowerCase();
 
   return {
     patterns: patternsRaw ? patternsRaw.split(/\s+/).filter(Boolean) : ["**/*.{jsx,tsx}"],
@@ -23,5 +25,9 @@ export function parseInputs(env: Record<string, string | undefined>): ActionInpu
     // Anything other than an explicit "false" keeps the safe default of
     // failing the job on violations.
     failOnViolations: failRaw !== "false",
+    // Opposite direction from failOnViolations above: strict is opt-in, so
+    // anything other than an explicit "true" keeps the safe default of the
+    // existing WCAG 2.5.8 (AA) 24px threshold.
+    strict: strictRaw === "true",
   };
 }

--- a/packages/github-action-tailwind-a11y/src/main.ts
+++ b/packages/github-action-tailwind-a11y/src/main.ts
@@ -27,7 +27,7 @@ function groupByFile(violations: AnyViolation[]): Map<string, AnyViolation[]> {
 }
 
 async function main(): Promise<void> {
-  const { patterns, config, failOnViolations } = parseInputs(process.env);
+  const { patterns, config, failOnViolations, strict } = parseInputs(process.env);
 
   // The runner launches this process with cwd = GITHUB_WORKSPACE (the
   // consumer's checkout), so process.cwd() is the right root for globbing,
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
       const code = readFileSync(absPath, "utf8");
       violations.push(
         ...checkContrast(extractChecks(code, file), palette),
-        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing)),
+        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
       );
     } catch (err) {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -107,6 +107,31 @@ Tailwind-class-level sizing or focus-style analysis).
   anywhere in the parent rather than adjacent to the target — was caught in
   review as the same shape-not-meaning failure class noted below, just at
   the sibling level instead of the token level.
+- **Touch target: `checkTouchTargets(checks, strict?)` has two thresholds,
+  both enforced by resolving against the same closed `spacingScale` lookup
+  table** (see the "real bug pattern" section below for why that lookup-
+  table design has no shape-not-meaning risk to begin with, regardless of
+  which threshold is active): the default 24×24px is WCAG 2.5.8 (Level AA);
+  opt-in `strict` raises it to WCAG **2.5.5** (Level AAA), 44×44px — verified
+  against the W3C Understanding doc that 2.5.5 has the same "target in a
+  sentence/text block" exemption as 2.5.8, so `isInlineInText()` above
+  applies unchanged to both thresholds; this only changes the number being
+  compared against, never how targets are found or exempted. Every adapter
+  exposes it the same opt-in, default-off way: CLI `--strict`, ESLint
+  `["error", { strict: true }]` rule option (the first rule option this
+  plugin has ever needed — `configPath` deliberately lives in
+  `settings["tailwind-a11y"]` instead, since it's cross-cutting across all
+  three rules and `strict` isn't), VS Code `tailwind-a11y.strict` setting,
+  GitHub Action `strict` input. `TouchTargetViolation` carries the active
+  threshold on the violation itself now (`required: number`, `level: "AA" |
+  "AAA"`), mirroring `ContrastViolation`'s existing shape — every formatter
+  (`cli.ts`, the ESLint rule's message, `vscode-tailwind-a11y/src/format.ts`,
+  `github-action-tailwind-a11y/src/annotations.ts`) reads this dynamically
+  rather than hardcoding "WCAG 2.5.8"/"24×24px", which is what all four
+  formatters did before `strict` existed (a real, if latent, bug — those
+  strings would have been silently wrong for any consumer using a stricter
+  threshold, so this was fixed alongside adding the option rather than left
+  for later).
 - **Focus indicator: `focus:` and `focus-visible:` are merged** for the
   removal-vs-replacement comparison, since the standard accessible pattern
   (`focus:outline-none focus-visible:ring-2`) spans both variants.

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,6 +25,7 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                              # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"               # custom glob
 npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
+npx tailwind-a11y --strict                     # touch targets must meet WCAG 2.5.5 (AAA, 44x44px), not just 2.5.8 (AA, 24x24px)
 npx tailwind-a11y --config ./tw.config.cjs     # use a specific config instead of auto-detecting
 npx tailwind-a11y --version                    # print the installed version
 npx tailwind-a11y --help                       # usage and all options
@@ -53,7 +54,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Check | WCAG | Detects |
 |---|---|---|
 | Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent, including a text-side opacity modifier (`text-gray-400/50`) composited against the background; suggests the nearest passing shade |
-| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px |
+| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
 ## Scope

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -30,8 +30,10 @@ function formatViolation(v: AnyViolation): string {
       const base = `${v.line}: ${v.textClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (${v.level})`;
       return v.suggestion ? `${base}; try ${v.suggestion} (${v.suggestedRatio!.toFixed(2)})` : base;
     }
-    case "touch-target":
-      return `${v.line}: <${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG 2.5.8 requires >= 24×24px`;
+    case "touch-target": {
+      const sc = v.level === "AAA" ? "2.5.5" : "2.5.8";
+      return `${v.line}: <${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG ${sc} requires >= ${v.required}×${v.required}px`;
+    }
     case "focus-indicator":
       return `${v.line}: <${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
   }
@@ -51,7 +53,7 @@ function groupByFile<T extends { file: string }>(items: T[]): Map<string, T[]> {
 }
 
 async function main(): Promise<void> {
-  const { help, version, verbose, config, configError: usageError, patterns } = parseArgs(process.argv.slice(2));
+  const { help, version, verbose, strict, config, configError: usageError, patterns } = parseArgs(process.argv.slice(2));
 
   if (help) {
     console.log(getHelpText());
@@ -98,7 +100,7 @@ async function main(): Promise<void> {
 
       violations.push(
         ...checkContrast(contrastChecks, palette),
-        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing)),
+        ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
       );
 

--- a/packages/tailwind-a11y/src/cliArgs.test.ts
+++ b/packages/tailwind-a11y/src/cliArgs.test.ts
@@ -7,6 +7,7 @@ describe("parseArgs", () => {
       help: false,
       version: false,
       verbose: false,
+      strict: false,
       config: null,
       configError: null,
       patterns: [],
@@ -16,6 +17,15 @@ describe("parseArgs", () => {
   it("recognizes --verbose and its short form -v", () => {
     expect(parseArgs(["--verbose"]).verbose).toBe(true);
     expect(parseArgs(["-v"]).verbose).toBe(true);
+  });
+
+  it("recognizes --strict", () => {
+    expect(parseArgs(["--strict"]).strict).toBe(true);
+    expect(parseArgs([]).strict).toBe(false);
+  });
+
+  it("does not treat --strict as a glob pattern", () => {
+    expect(parseArgs(["--strict"]).patterns).toEqual([]);
   });
 
   it("recognizes --version and its short form -V (uppercase, distinct from -v)", () => {
@@ -74,6 +84,7 @@ describe("getHelpText", () => {
     expect(text).toContain("--verbose");
     expect(text).toContain("--version");
     expect(text).toContain("--help");
+    expect(text).toContain("--strict");
     expect(text).toContain("--config");
   });
 });

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -5,6 +5,7 @@ export interface ParsedArgs {
   help: boolean;
   version: boolean;
   verbose: boolean;
+  strict: boolean;
   config: string | null;
   configError: string | null;
   patterns: string[];
@@ -19,6 +20,8 @@ Options:
   -v, --verbose      Also report what couldn't be checked, and why
   -V, --version      Print the version number
   -h, --help         Print this help message
+      --strict       Touch targets must meet WCAG 2.5.5 (AAA, 44x44px)
+                      instead of the default 2.5.8 (AA, 24x24px)
       --config <path>  Path to a tailwind.config.js/.cjs (v3) or a CSS
                         @theme file like app/globals.css (v4) to read
                         custom theme colors/spacing from (default:
@@ -28,6 +31,7 @@ Examples:
   tailwind-a11y                    Scan **/*.{jsx,tsx} from the current directory
   tailwind-a11y "src/**/*.tsx"     Scan a custom glob pattern
   tailwind-a11y --verbose          Also report skipped/unresolvable cases
+  tailwind-a11y --strict           Enforce the stricter 44x44px touch target minimum
   tailwind-a11y --config ./tailwind.config.cjs
 `;
 
@@ -37,7 +41,7 @@ export function getHelpText(): string {
 
 // -v/--verbose already existed before --version was added; -V (uppercase)
 // avoids colliding with it, matching a common CLI convention.
-const FLAGS = new Set(["--verbose", "-v", "--version", "-V", "--help", "-h"]);
+const FLAGS = new Set(["--verbose", "-v", "--version", "-V", "--help", "-h", "--strict"]);
 
 export function parseArgs(argv: string[]): ParsedArgs {
   let config: string | null = null;
@@ -67,6 +71,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     help: argv.includes("--help") || argv.includes("-h"),
     version: argv.includes("--version") || argv.includes("-V"),
     verbose: argv.includes("--verbose") || argv.includes("-v"),
+    strict: argv.includes("--strict"),
     config,
     configError,
     patterns,

--- a/packages/tailwind-a11y/src/rules/checkTouchTarget.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkTouchTarget.test.ts
@@ -8,7 +8,18 @@ describe("checkTouchTargets", () => {
       { file: "f.tsx", line: 1, tagName: "button", widthClass: "w-4", heightClass: "h-4", widthPx: 16, heightPx: 16 },
     ]);
     expect(violations).toEqual([
-      { type: "touch-target", file: "f.tsx", line: 1, tagName: "button", widthClass: "w-4", heightClass: "h-4", widthPx: 16, heightPx: 16 },
+      {
+        type: "touch-target",
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        widthClass: "w-4",
+        heightClass: "h-4",
+        widthPx: 16,
+        heightPx: 16,
+        required: 24,
+        level: "AA",
+      },
     ]);
   });
 
@@ -39,7 +50,54 @@ describe("checkTouchTargets", () => {
     ]);
     // Same wording as cli.ts's formatViolation (touch-target case).
     console.log(
-      `${v.line}: <${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG 2.5.8 requires >= 24×24px`
+      `${v.line}: <${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG ${v.level === "AAA" ? "2.5.5" : "2.5.8"} requires >= ${v.required}×${v.required}px`
     );
+  });
+
+  describe("strict mode (WCAG 2.5.5 AAA, 44x44)", () => {
+    it("does not flag a 40x40 target by default (passes AA's 24px minimum)", () => {
+      const violations = checkTouchTargets([
+        { file: "f.tsx", line: 1, tagName: "button", widthClass: "w-10", heightClass: "h-10", widthPx: 40, heightPx: 40 },
+      ]);
+      expect(violations).toEqual([]);
+    });
+
+    it("flags the same 40x40 target under strict mode (fails AAA's 44px minimum)", () => {
+      const violations = checkTouchTargets(
+        [{ file: "f.tsx", line: 1, tagName: "button", widthClass: "w-10", heightClass: "h-10", widthPx: 40, heightPx: 40 }],
+        true
+      );
+      expect(violations).toEqual([
+        {
+          type: "touch-target",
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          widthClass: "w-10",
+          heightClass: "h-10",
+          widthPx: 40,
+          heightPx: 40,
+          required: 44,
+          level: "AAA",
+        },
+      ]);
+    });
+
+    it("passes exactly 44x44 under strict mode (minimum is inclusive, same as AA's 24px)", () => {
+      const violations = checkTouchTargets(
+        [{ file: "f.tsx", line: 1, tagName: "button", widthClass: "w-11", heightClass: "h-11", widthPx: 44, heightPx: 44 }],
+        true
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it("still flags a target below both thresholds under strict mode, reporting the strict values", () => {
+      const violations = checkTouchTargets(
+        [{ file: "f.tsx", line: 1, tagName: "button", widthClass: "w-4", heightClass: "h-4", widthPx: 16, heightPx: 16 }],
+        true
+      );
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toMatchObject({ required: 44, level: "AAA" });
+    });
   });
 });

--- a/packages/tailwind-a11y/src/rules/checkTouchTarget.ts
+++ b/packages/tailwind-a11y/src/rules/checkTouchTarget.ts
@@ -9,14 +9,30 @@ export interface TouchTargetViolation {
   heightClass: string;
   widthPx: number;
   heightPx: number;
+  required: number;
+  // Unlike ContrastViolation's level (always "AA" -- no AAA contrast check
+  // exists yet), this is a real union: strict mode genuinely switches which
+  // WCAG success criterion is being enforced, not just a stricter number
+  // under the same one.
+  level: "AA" | "AAA";
 }
 
 // WCAG 2.5.8 Target Size (Minimum), Level AA: interactive targets must be
 // at least 24x24 CSS pixels. "Minimum" is inclusive, so exactly 24x24 passes.
 const MIN_TARGET_PX = 24;
 
-export function checkTouchTargets(checks: TouchTargetCheck[]): TouchTargetViolation[] {
+// WCAG 2.5.5 Target Size (Enhanced), Level AAA: 44x44 CSS pixels -- opt-in
+// via `strict`, not the default. Same "target in a sentence/text block"
+// exemption as 2.5.8 (verified against the W3C Understanding doc), so
+// extractTouchTargets.ts's isInlineInText() exemption logic applies
+// unchanged to both thresholds -- this file only changes which number is
+// compared against, not how targets are found or exempted.
+const MIN_TARGET_PX_STRICT = 44;
+
+export function checkTouchTargets(checks: TouchTargetCheck[], strict = false): TouchTargetViolation[] {
+  const required = strict ? MIN_TARGET_PX_STRICT : MIN_TARGET_PX;
+  const level = strict ? "AAA" : "AA";
   return checks
-    .filter((c) => c.widthPx < MIN_TARGET_PX || c.heightPx < MIN_TARGET_PX)
-    .map((c) => ({ type: "touch-target" as const, ...c }));
+    .filter((c) => c.widthPx < required || c.heightPx < required)
+    .map((c) => ({ type: "touch-target" as const, ...c, required, level }));
 }

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -12,7 +12,7 @@ reimplemented here.
 | Check | WCAG | Detects |
 |---|---|---|
 | Contrast | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — with a suggested nearby shade |
-| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px |
+| Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
@@ -28,6 +28,13 @@ setting:
 
 ```json
 { "tailwind-a11y.configPath": "./app/globals.css" }
+```
+
+Set `tailwind-a11y.strict` to enforce the stricter 44×44px touch target
+minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA):
+
+```json
+{ "tailwind-a11y.strict": true }
 ```
 
 ## License

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -36,6 +36,12 @@
           "default": "",
           "scope": "resource",
           "description": "Path to a tailwind.config.js/.cjs (v3) or a CSS @theme file like app/globals.css (v4), relative to the workspace folder. Overrides auto-detection."
+        },
+        "tailwind-a11y.strict": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px)."
         }
       }
     }
@@ -60,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.8.0"
+    "tailwind-a11y": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -77,8 +77,10 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
   // onDidChangeConfiguration listener needed, the next debounced/save-
   // triggered refresh() just picks up a changed setting on its own.
   const rootDir = vscode.workspace.getWorkspaceFolder(doc.uri)?.uri.fsPath ?? null;
-  const rawConfigPath = vscode.workspace.getConfiguration("tailwind-a11y", doc.uri).get<string>("configPath");
+  const settings = vscode.workspace.getConfiguration("tailwind-a11y", doc.uri);
+  const rawConfigPath = settings.get<string>("configPath");
   const configPath = resolveConfigPathSetting(rawConfigPath, rootDir);
+  const strict = settings.get<boolean>("strict") ?? false;
   const { palette, spacing, configError } = resolveTheme({ rootDir, configPath });
   // configError only ever fires for an explicit configPath that failed to
   // load -- auto-detection failure stays silent by design (see
@@ -89,7 +91,7 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
 
   const violations: AnyViolation[] = [
     ...checkContrast(extractChecks(text, file), palette),
-    ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing)),
+    ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing), strict),
     ...checkFocusIndicators(extractFocusIndicatorChecks(text, file)),
   ];
 

--- a/packages/vscode-tailwind-a11y/src/format.test.ts
+++ b/packages/vscode-tailwind-a11y/src/format.test.ts
@@ -42,8 +42,26 @@ describe("formatViolation", () => {
       heightClass: "h-4",
       widthPx: 16,
       heightPx: 16,
+      required: 24,
+      level: "AA",
     });
     expect(message).toBe("<button> is 16×16px (w-4 h-4) — WCAG 2.5.8 requires >= 24×24px");
+  });
+
+  it("formats a strict-mode touch-target violation with WCAG 2.5.5 and the 44px threshold", () => {
+    const message = formatViolation({
+      type: "touch-target",
+      file: "f.tsx",
+      line: 2,
+      tagName: "button",
+      widthClass: "w-10",
+      heightClass: "h-10",
+      widthPx: 40,
+      heightPx: 40,
+      required: 44,
+      level: "AAA",
+    });
+    expect(message).toBe("<button> is 40×40px (w-10 h-10) — WCAG 2.5.5 requires >= 44×44px");
   });
 
   it("formats a focus-indicator violation", () => {

--- a/packages/vscode-tailwind-a11y/src/format.ts
+++ b/packages/vscode-tailwind-a11y/src/format.ts
@@ -12,8 +12,10 @@ export function formatViolation(v: AnyViolation): string {
       const base = `${v.textClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (${v.level})`;
       return v.suggestion ? `${base}; try ${v.suggestion} (${v.suggestedRatio!.toFixed(2)})` : base;
     }
-    case "touch-target":
-      return `<${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG 2.5.8 requires >= 24×24px`;
+    case "touch-target": {
+      const sc = v.level === "AAA" ? "2.5.5" : "2.5.8";
+      return `<${v.tagName}> is ${v.widthPx}×${v.heightPx}px (${v.widthClass} ${v.heightClass}) — WCAG ${sc} requires >= ${v.required}×${v.required}px`;
+    }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
   }


### PR DESCRIPTION
## What

Touch-target checking only ever enforced WCAG 2.5.8 (AA, 24x24px), a legal-compliance floor rather than a comfortable real-world target. This adds an opt-in `strict` mode that switches to WCAG 2.5.5 (AA, 44x44px) instead, matching Apple HIG (44pt) and Material Design (48dp) guidance. Default stays 24px everywhere, so nothing changes for existing users unless they turn it on.

It's exposed the same way across all four packages: `--strict` on the CLI, a `{ strict: true }` rule option in the ESLint plugin, a `tailwind-a11y.strict` VS Code setting, and a `strict` GitHub Action input.

## Why 44px

WCAG 2.5.5 has the same "target sits inside a sentence or block of text" exemption as 2.5.8, so the existing inline-text exemption logic didn't need any changes, just a different threshold number. Motor-impairment research backs 44px as a meaningful step up rather than an arbitrary round number: essential tremor affects 4% of people under 40 and 14% over 65, and mis-tap rates run 40-60% higher right at the 24px minimum for people with tremor.

## Along the way

The four adapters were each hardcoding "WCAG 2.5.8 requires >= 24x24px" as a literal string in their formatters, since the violation object never carried its own threshold. That would've been silently wrong the instant the threshold became configurable, so `TouchTargetViolation` now carries `required`/`level` fields (mirroring how `ContrastViolation` already works) and all four formatters read from those instead of hardcoding text.

## Versions

Engine, ESLint plugin, and GitHub Action all go 0.8.0 -> 0.9.0. The VS Code extension goes to 0.10.0 instead of 0.9.0, since 0.9.0 was already published for the earlier config-path setting.

## Test plan

- [x] Full test suite passes across all four packages
- [x] Manual smoke test with a 40x40px fixture: passes by default, fails under strict, in the CLI, ESLint, and GitHub Action
- [x] GitHub Action bundle rebuilt and confirmed non-stale
- [x] Independent review pass confirmed all four formatter sites were fixed (not just some) and re-verified the WCAG 2.5.5 exemption against the W3C doc directly