### PR TITLE
Add focus indicator contrast check: WCAG 1.4.11 + 2.4.13 under strict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ fourth check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.9.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.10.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6648,10 +6648,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.9.0"
+        "tailwind-a11y": "^0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6667,11 +6667,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.9.0"
+        "tailwind-a11y": "^0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6681,7 +6681,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6705,10 +6705,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.9.0"
+        "tailwind-a11y": "^0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -32,6 +32,7 @@ export default [
       "tailwind-a11y/contrast": "error",
       "tailwind-a11y/touch-target": "warn",
       "tailwind-a11y/focus-indicator": "error",
+      "tailwind-a11y/focus-contrast": "error",
     },
   },
 ];
@@ -44,6 +45,7 @@ export default [
 | `contrast` | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — suggests the nearest passing shade |
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
+| `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 
@@ -60,10 +62,15 @@ export default [
 ];
 ```
 
-## Stricter touch targets
+## Stricter (AAA) mode
 
-`touch-target` defaults to WCAG 2.5.8 (AA, 24×24px). Pass `{ strict: true }`
-as a rule option to enforce 2.5.5 (AAA, 44×44px) instead:
+`touch-target` and `focus-contrast` each default to their AA tier. Pass
+`{ strict: true }` as each rule's own option to hold it to its AAA tier
+instead — `touch-target` to 2.5.5 (44×44px), `focus-contrast` to also
+require 2.4.13's minimum indicator thickness on top of its always-on 3:1
+contrast check. Each rule's `strict` option is independent — there's no
+single flag that turns both on at once in ESLint, unlike the CLI/VS
+Code/GitHub Action, which do share one:
 
 ```js
 export default [
@@ -72,6 +79,7 @@ export default [
     plugins: { "tailwind-a11y": tailwindA11y },
     rules: {
       "tailwind-a11y/touch-target": ["warn", { strict: true }],
+      "tailwind-a11y/focus-contrast": ["warn", { strict: true }],
     },
   },
 ];

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.9.0"
+    "tailwind-a11y": "^0.10.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/index.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/index.ts
@@ -3,6 +3,7 @@ import type { ESLint } from "eslint";
 import contrast from "./rules/contrast.js";
 import touchTarget from "./rules/touch-target.js";
 import focusIndicator from "./rules/focus-indicator.js";
+import focusContrast from "./rules/focus-contrast.js";
 
 // `../package.json` resolves correctly from both `src/` (dev) and `dist/`
 // (published), so the plugin version can't drift from the package version.
@@ -19,6 +20,7 @@ const plugin: ESLint.Plugin = {
     contrast,
     "touch-target": touchTarget,
     "focus-indicator": focusIndicator,
+    "focus-contrast": focusContrast,
   },
   configs: {},
 };
@@ -42,6 +44,7 @@ Object.assign(plugin.configs!, {
         "tailwind-a11y/contrast": "error",
         "tailwind-a11y/touch-target": "error",
         "tailwind-a11y/focus-indicator": "error",
+        "tailwind-a11y/focus-contrast": "error",
       },
     },
   ],

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/focus-contrast.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/focus-contrast.test.ts
@@ -1,0 +1,70 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import rule from "./focus-contrast.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run("focus-contrast", rule, {
+  valid: [
+    {
+      name: "a high-contrast ring (white on blue-500) passes by default",
+      filename: "Ok.jsx",
+      code: `export const Ok = () => <button className="bg-blue-500 focus:outline-none focus:ring-2 focus:ring-white" onClick={() => {}}>x</button>;`,
+    },
+    {
+      name: "a high-contrast, sufficiently-thick ring passes under strict too",
+      filename: "OkStrict.jsx",
+      code: `export const Ok = () => <button className="bg-blue-500 focus:outline-none focus:ring-2 focus:ring-white" onClick={() => {}}>x</button>;`,
+      options: [{ strict: true }],
+    },
+    {
+      name: "no explicit outline-*/ring-* color is out of scope, not flagged",
+      filename: "NoColor.jsx",
+      code: `export const D = () => <button className="bg-blue-500 focus:outline-none focus:border-4 focus:border-blue-400" onClick={() => {}}>x</button>;`,
+    },
+    {
+      name: "thin ring-1 passes by default (thickness only assessed under strict)",
+      filename: "Thin.jsx",
+      code: `export const Ok = () => <button className="bg-blue-500 focus:outline-none focus:ring-1 focus:ring-white" onClick={() => {}}>x</button>;`,
+    },
+  ],
+  invalid: [
+    {
+      name: "a low-contrast ring (blue-400 on blue-500) fails by default — the case focus-indicator alone misses",
+      filename: "LowContrast.jsx",
+      code: `export const B = () => <button className="bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400" onClick={() => {}}>x</button>;`,
+      errors: [
+        {
+          message: "<button> focus indicator focus:ring-blue-400 on bg-blue-500 — ratio 1.45, needs 3 (WCAG 1.4.11)",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      name: "a high-contrast but too-thin ring fails under strict — thickness is independent of contrast",
+      filename: "Thin.jsx",
+      code: `export const B = () => <button className="bg-blue-500 focus:outline-none focus:ring-1 focus:ring-white" onClick={() => {}}>x</button>;`,
+      options: [{ strict: true }],
+      errors: [
+        {
+          message:
+            "<button> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+  ],
+  assertionOptions: { requireLocation: true, requireMessage: true },
+});

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/focus-contrast.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/focus-contrast.ts
@@ -1,0 +1,61 @@
+import type { Rule } from "eslint";
+import { extractFocusIndicatorChecks, checkFocusContrast } from "tailwind-a11y";
+import { resolveThemeForContext } from "../theme.js";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce WCAG 1.4.11 AA (3:1) contrast for focus indicators — flag a present outline/ring whose color is too close to the background to actually see",
+      recommended: true,
+      url: "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#focus-contrast",
+    },
+    // strict is this rule's own option (WCAG 2.4.13 AAA minimum thickness),
+    // independently configurable from touch-target's identically-shaped
+    // strict option -- see touch-target.ts for why this lives in options,
+    // not context.settings.
+    schema: [{ type: "object", properties: { strict: { type: "boolean" } }, additionalProperties: false }],
+    messages: {
+      focusContrast:
+        "<{{tagName}}> focus indicator {{indicatorClass}} on {{bgClass}} — ratio {{ratio}}, needs {{required}} (WCAG {{wcagSC}})",
+      focusContrastWithThickness:
+        "<{{tagName}}> focus indicator {{indicatorClass}} on {{bgClass}} — ratio {{ratio}}, needs {{required}} (WCAG {{wcagSC}}); also only {{thicknessPx}}px thick, needs >= {{requiredThicknessPx}}px",
+    },
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const { palette } = resolveThemeForContext(context);
+        const strict = (context.options[0] as { strict?: boolean } | undefined)?.strict ?? false;
+        const violations = checkFocusContrast(
+          extractFocusIndicatorChecks(context.sourceCode.getText(), context.filename),
+          strict,
+          palette
+        );
+
+        for (const v of violations) {
+          const wcagSC = v.level === "AAA" ? "2.4.13" : "1.4.11";
+          context.report({
+            loc: { line: v.line, column: 0 },
+            messageId: v.thicknessPx !== undefined ? "focusContrastWithThickness" : "focusContrast",
+            data: {
+              tagName: v.tagName,
+              indicatorClass: v.indicatorClass,
+              bgClass: v.bgClass,
+              ratio: v.ratio.toFixed(2),
+              required: String(v.required),
+              wcagSC,
+              ...(v.thicknessPx !== undefined
+                ? { thicknessPx: String(v.thicknessPx), requiredThicknessPx: String(v.requiredThicknessPx) }
+                : {}),
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -30,7 +30,7 @@ found (configurable below).
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
 | `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
-| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px) |
+| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check |
 
 ```yaml
 - uses: chamroro/tailwind-a11y@v0

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -5970,7 +5970,7 @@ var require_generated = __commonJS({
     exports2.isJSXAttribute = isJSXAttribute3;
     exports2.isJSXClosingElement = isJSXClosingElement;
     exports2.isJSXClosingFragment = isJSXClosingFragment;
-    exports2.isJSXElement = isJSXElement3;
+    exports2.isJSXElement = isJSXElement4;
     exports2.isJSXEmptyExpression = isJSXEmptyExpression;
     exports2.isJSXExpressionContainer = isJSXExpressionContainer;
     exports2.isJSXFragment = isJSXFragment2;
@@ -6939,7 +6939,7 @@ var require_generated = __commonJS({
       if (node.type !== "JSXClosingElement") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
     }
-    function isJSXElement3(node, opts) {
+    function isJSXElement4(node, opts) {
       if (!node) return false;
       if (node.type !== "JSXElement") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
@@ -49565,7 +49565,7 @@ var semanticColors = {
 
 // ../tailwind-a11y/dist/rules/checkContrast.js
 function resolveColorValue(utilityClass, palette = defaultPalette) {
-  const match = /^(?:text|bg)-(.+)$/.exec(utilityClass);
+  const match = /^(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
   if (!match)
     return null;
   const token = match[1];
@@ -49812,11 +49812,27 @@ function extractFocusIndicatorChecks(code, filePath) {
       const focusClasses = focusScopedClasses(className);
       if (focusClasses.length === 0)
         return;
+      const ownBg = lastColorToken(className, "bg");
+      let bgClass = ownBg;
+      let bgSource = ownBg ? "self" : null;
+      if (!bgClass) {
+        const parentNode = path.parentPath?.node;
+        if (parentNode && t5.isJSXElement(parentNode)) {
+          const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
+          const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
+          if (parentBg) {
+            bgClass = parentBg;
+            bgSource = "parent";
+          }
+        }
+      }
       checks.push({
         file: filePath,
         line: opening.loc?.start.line ?? 0,
         tagName: t5.isJSXIdentifier(opening.name) ? opening.name.name : "onClick-element",
-        focusClasses
+        focusClasses,
+        bgClass,
+        bgSource
       });
     }
   });
@@ -49906,6 +49922,84 @@ function checkFocusIndicators(checks) {
       line: check.line,
       tagName: check.tagName,
       removalClass: removal
+    });
+  }
+  return violations;
+}
+var NON_TEXT_MIN_RATIO = 3;
+var FOCUS_INDICATOR_MIN_THICKNESS_PX = 2;
+var WIDTH_SCALE = { "0": 0, "1": 1, "2": 2, "4": 4, "8": 8 };
+function lastIndicatorColorToken(focusClasses) {
+  let found = null;
+  for (const raw of focusClasses) {
+    const base = raw.slice(raw.lastIndexOf(":") + 1);
+    const match = /^(?:outline|ring)-(.+)$/.exec(base);
+    if (!match)
+      continue;
+    const rest = match[1];
+    if (!COLOR_TOKEN.test(rest))
+      continue;
+    const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
+    if (scaleName === "opacity")
+      continue;
+    found = base;
+  }
+  return found;
+}
+function lastIndicatorThicknessPx(focusClasses) {
+  let found = null;
+  for (const raw of focusClasses) {
+    const base = raw.slice(raw.lastIndexOf(":") + 1);
+    const match = /^(?:outline|ring)-(.+)$/.exec(base);
+    if (!match)
+      continue;
+    const token = match[1];
+    if (token in WIDTH_SCALE) {
+      found = WIDTH_SCALE[token];
+      continue;
+    }
+    const arbitrary = /^\[(\d+(?:\.\d+)?)px\]$/.exec(token);
+    if (arbitrary)
+      found = Number(arbitrary[1]);
+  }
+  return found;
+}
+function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
+  const violations = [];
+  for (const check of checks) {
+    if (!check.bgClass)
+      continue;
+    const indicatorBase = lastIndicatorColorToken(check.focusClasses);
+    if (!indicatorBase)
+      continue;
+    const indicatorHex = resolveColorValue(indicatorBase, palette);
+    const bgHex = resolveColorValue(check.bgClass, palette);
+    if (!indicatorHex || !bgHex)
+      continue;
+    const indicatorRgb = hexToRgb(indicatorHex);
+    const bgRgb = hexToRgb(bgHex);
+    if (!indicatorRgb || !bgRgb)
+      continue;
+    const ratio = contrastRatio(indicatorRgb, bgRgb);
+    const contrastFails = ratio < NON_TEXT_MIN_RATIO;
+    let thicknessPx = null;
+    if (strict)
+      thicknessPx = lastIndicatorThicknessPx(check.focusClasses);
+    const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
+    if (!contrastFails && !thicknessFails)
+      continue;
+    const rawIndicatorClass = check.focusClasses.find((raw) => raw.slice(raw.lastIndexOf(":") + 1) === indicatorBase);
+    violations.push({
+      type: "focus-contrast",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      indicatorClass: rawIndicatorClass,
+      bgClass: check.bgClass,
+      ratio,
+      required: NON_TEXT_MIN_RATIO,
+      level: thicknessFails ? "AAA" : "AA",
+      ...thicknessFails && thicknessPx !== null ? { thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX } : {}
     });
   }
   return violations;
@@ -50172,6 +50266,11 @@ function formatViolation(v) {
     }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
+    case "focus-contrast": {
+      const sc = v.level === "AAA" ? "2.4.13" : "1.4.11";
+      const base = `<${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} \u2014 ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
+      return v.thicknessPx !== void 0 ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px` : base;
+    }
   }
 }
 function toAnnotationCommand(v) {
@@ -50211,10 +50310,12 @@ async function main() {
     const file = (0, import_node_path2.relative)(cwd, absPath).split(import_node_path2.sep).join("/");
     try {
       const code = (0, import_node_fs2.readFileSync)(absPath, "utf8");
+      const focusChecks = extractFocusIndicatorChecks(code, file);
       violations.push(
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
-        ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
+        ...checkFocusIndicators(focusChecks),
+        ...checkFocusContrast(focusChecks, strict, palette)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${err.message}`);

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.9.0",
+    "tailwind-a11y": "^0.10.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/src/annotations.test.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.test.ts
@@ -76,6 +76,40 @@ describe("formatViolation", () => {
       "<a> removes the focus outline (focus:outline-none) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)"
     );
   });
+
+  it("formats a focus-contrast violation (contrast only, AA)", () => {
+    const message = formatViolation({
+      type: "focus-contrast",
+      file: "src/Link.tsx",
+      line: 8,
+      tagName: "a",
+      indicatorClass: "focus:ring-blue-400",
+      bgClass: "bg-blue-500",
+      ratio: 1.45,
+      required: 3,
+      level: "AA",
+    });
+    expect(message).toBe("<a> focus indicator focus:ring-blue-400 on bg-blue-500 — ratio 1.45, needs 3 (WCAG 1.4.11)");
+  });
+
+  it("formats a strict-mode focus-contrast violation with a thickness failure (AAA)", () => {
+    const message = formatViolation({
+      type: "focus-contrast",
+      file: "src/Link.tsx",
+      line: 8,
+      tagName: "a",
+      indicatorClass: "focus:ring-white",
+      bgClass: "bg-blue-500",
+      ratio: 3.68,
+      required: 3,
+      level: "AAA",
+      thicknessPx: 1,
+      requiredThicknessPx: 2,
+    });
+    expect(message).toBe(
+      "<a> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
+    );
+  });
 });
 
 describe("toAnnotationCommand", () => {

--- a/packages/github-action-tailwind-a11y/src/annotations.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.ts
@@ -1,6 +1,6 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation } from "tailwind-a11y";
+import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation;
+export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
 
 // GitHub renders roughly 10 annotations per type per step (and ~50 per job) --
 // undocumented, observed limits. Correctness never rides on annotations:
@@ -35,6 +35,13 @@ export function formatViolation(v: AnyViolation): string {
     }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
+    case "focus-contrast": {
+      const sc = v.level === "AAA" ? "2.4.13" : "1.4.11";
+      const base = `<${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
+      return v.thicknessPx !== undefined
+        ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
+        : base;
+    }
   }
 }
 

--- a/packages/github-action-tailwind-a11y/src/main.ts
+++ b/packages/github-action-tailwind-a11y/src/main.ts
@@ -8,6 +8,7 @@ import {
   checkTouchTargets,
   extractFocusIndicatorChecks,
   checkFocusIndicators,
+  checkFocusContrast,
   resolveTheme,
 } from "tailwind-a11y";
 import { parseInputs } from "./inputs.js";
@@ -58,10 +59,12 @@ async function main(): Promise<void> {
 
     try {
       const code = readFileSync(absPath, "utf8");
+      const focusChecks = extractFocusIndicatorChecks(code, file);
       violations.push(
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
-        ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
+        ...checkFocusIndicators(focusChecks),
+        ...checkFocusContrast(focusChecks, strict, palette)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${(err as Error).message}`);

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -12,7 +12,7 @@ published consumers, not free pre-launch churn.)
 
 A static analysis CLI that catches WCAG accessibility violations in Tailwind
 CSS class combinations before they ship: color contrast, touch target size,
-and focus indicator removal. Existing contrast tools (e.g.
+and focus indicator removal/contrast. Existing contrast tools (e.g.
 `tailwindcss-contrast-checker`) only catch `text-*`/`bg-*` on the *same*
 element; this tool also catches the much more common **direct-parent**
 pattern:
@@ -160,6 +160,50 @@ Tailwind-class-level sizing or focus-style analysis).
     (they style child elements via a `> * + *` selector, not the element
     carrying the `focus:` class itself, so they're structurally inapplicable
     here regardless of visibility).
+- **Focus indicator contrast: `checkFocusContrast(checks, strict?)` is a
+  second, independent check on the same `focus:`/`focus-visible:` classes** —
+  `checkFocusIndicators` above only asks "was the outline removed with
+  nothing put back"; it never looks at whether a present indicator is
+  actually *visible*. `focus:outline focus:outline-2 focus:outline-blue-400`
+  on `bg-blue-500` reported zero violations before this check existed, even
+  though `blue-400`-on-`blue-500` is nowhere near visible. WCAG **1.4.11**
+  Non-text Contrast (AA) requires 3:1 for UI-component state indicators —
+  explicitly including focus indicators, per the W3C Understanding doc — and
+  is always enforced. **2.4.13** Focus Appearance (AAA, opt-in `strict`) does
+  **not** raise that 3:1 the way touch-target's AA→AAA does; it adds a
+  second, independent minimum-thickness requirement (>= a 2 CSS pixel
+  perimeter). A pure-contrast failure is always reported as `level: "AA"`
+  even under `strict`; only a thickness failure is `"AAA"` — the violation's
+  `level` reflects which SC actually failed, not just whether `strict` is on.
+  - Deliberately narrow scope: only an explicit `outline-{color}`/`ring-
+    {color}` under `focus:`/`focus-visible:` counts as "the indicator" —
+    `border-*`/`bg-*`/`shadow-*` replacements (valid for the 2.4.7 removal
+    check above) aren't resolved for contrast. Background resolution reuses
+    `extractClasses.ts`'s same-element-or-immediate-parent walk; unresolvable
+    → skipped, not guessed.
+  - Verified against a real `tailwindcss@4.3.3` compile: bare `ring`/
+    `outline` (no width digit) both resolve to `1px` in Tailwind v4, but
+    v3's bare `ring` default is documented elsewhere as `3px` — a real
+    cross-version difference this tool can't currently distinguish. So only
+    an explicit `outline-{0,1,2,4,8}`/`ring-{0,1,2,4,8}` or an arbitrary
+    `[Npx]` resolves a thickness value; bare `ring`/`outline` contributes
+    color (if paired with an explicit color utility) but the thickness
+    dimension is silently left unassessed for it under `strict`, never
+    asserted a false pass or fail.
+  - The 3:1 threshold is a flat local constant (`NON_TEXT_MIN_RATIO`), not
+    `luminance.ts`'s `requiredRatio()`/`meetsWCAG()` — those model the
+    text-specific large-text/small-text AA/AAA table, which doesn't apply to
+    UI-component contrast. `resolveColorValue()` (`checkContrast.ts`) is
+    generalized from its `text`/`bg` prefix union to also accept `outline`/
+    `ring` — same palette/arbitrary-hex/semantic-color resolution, reused
+    rather than duplicated.
+  - Exposed the same opt-in way as touch-target's `strict`, reusing the
+    exact same flag: CLI `--strict`, VS Code `tailwind-a11y.strict` setting,
+    GitHub Action `strict` input all now affect both checks from one toggle.
+    ESLint is the one exception — `tailwind-a11y/focus-contrast` has its own,
+    independently-configurable `strict` rule option (own file, own schema),
+    since ESLint has no plugin-wide toggle and each rule's options are
+    already independently set.
 - **Contrast: opacity modifiers (`text-gray-400/50`) are resolved on the
   *text* side only**, composited against the already-resolved (fully opaque)
   background — see `resolveTextColorWithOpacity()`/`applyAlpha()` in
@@ -218,9 +262,12 @@ src/
                                      suggestContrastFix() — nearest passing
                                      shade in the same color scale (text side
                                      only, bg and any opacity held fixed)
-  rules/checkTouchTarget.ts       — touch target violations (WCAG 2.5.8, AA)
-  rules/checkFocusIndicator.ts    — focus indicator violations (WCAG 2.4.7, AA)
-  cli.ts                         — fast-glob scan, run all three checkers,
+  rules/checkTouchTarget.ts       — touch target violations (WCAG 2.5.8 AA /
+                                     2.5.5 AAA under strict)
+  rules/checkFocusIndicator.ts    — focus indicator removal (WCAG 2.4.7, AA)
+                                     and focus indicator contrast (WCAG
+                                     1.4.11 AA / 2.4.13 AAA under strict)
+  cli.ts                         — fast-glob scan, run all four checkers,
                                     print report, exit 1 on any violations (CI)
   cliArgs.ts                     — flag parsing, including --config <path>
 ```

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,7 +25,7 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                              # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"               # custom glob
 npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
-npx tailwind-a11y --strict                     # touch targets must meet WCAG 2.5.5 (AAA, 44x44px), not just 2.5.8 (AA, 24x24px)
+npx tailwind-a11y --strict                     # touch targets: WCAG 2.5.5 (AAA, 44x44px); focus indicators: also WCAG 2.4.13 (AAA, min thickness)
 npx tailwind-a11y --config ./tw.config.cjs     # use a specific config instead of auto-detecting
 npx tailwind-a11y --version                    # print the installed version
 npx tailwind-a11y --help                       # usage and all options
@@ -56,6 +56,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent, including a text-side opacity modifier (`text-gray-400/50`) composited against the background; suggests the nearest passing shade |
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
+| Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |
 
 ## Scope
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -8,7 +8,12 @@ import { checkContrast, checkContrastValueSkips, type ContrastViolation } from "
 import { extractTouchTargetChecks, extractTouchTargetSkips } from "./parser/extractTouchTargets.js";
 import { checkTouchTargets, type TouchTargetViolation } from "./rules/checkTouchTarget.js";
 import { extractFocusIndicatorChecks } from "./parser/extractFocusIndicators.js";
-import { checkFocusIndicators, type FocusIndicatorViolation } from "./rules/checkFocusIndicator.js";
+import {
+  checkFocusContrast,
+  checkFocusIndicators,
+  type FocusContrastViolation,
+  type FocusIndicatorViolation,
+} from "./rules/checkFocusIndicator.js";
 import { parseArgs, getHelpText } from "./cliArgs.js";
 import { resolveTheme } from "./theme/loadCustomTheme.js";
 
@@ -16,7 +21,7 @@ import { resolveTheme } from "./theme/loadCustomTheme.js";
 const require = createRequire(import.meta.url);
 const { version: packageVersion } = require("../package.json") as { version: string };
 
-type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation;
+type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
 
 interface Skip {
   file: string;
@@ -36,6 +41,13 @@ function formatViolation(v: AnyViolation): string {
     }
     case "focus-indicator":
       return `${v.line}: <${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
+    case "focus-contrast": {
+      const sc = v.level === "AAA" ? "2.4.13" : "1.4.11";
+      const base = `${v.line}: <${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
+      return v.thicknessPx !== undefined
+        ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
+        : base;
+    }
   }
 }
 
@@ -97,11 +109,13 @@ async function main(): Promise<void> {
     try {
       const code = readFileSync(absPath, "utf8");
       const contrastChecks = extractChecks(code, file);
+      const focusChecks = extractFocusIndicatorChecks(code, file);
 
       violations.push(
         ...checkContrast(contrastChecks, palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
-        ...checkFocusIndicators(extractFocusIndicatorChecks(code, file))
+        ...checkFocusIndicators(focusChecks),
+        ...checkFocusContrast(focusChecks, strict, palette)
       );
 
       if (verbose) {

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -14,14 +14,16 @@ export interface ParsedArgs {
 const HELP_TEXT = `Usage: tailwind-a11y [options] [<glob>...]
 
 Static analysis for Tailwind CSS accessibility violations -- color contrast,
-touch target size, and focus indicator removal.
+touch target size, and focus indicator removal/contrast.
 
 Options:
   -v, --verbose      Also report what couldn't be checked, and why
   -V, --version      Print the version number
   -h, --help         Print this help message
       --strict       Touch targets must meet WCAG 2.5.5 (AAA, 44x44px)
-                      instead of the default 2.5.8 (AA, 24x24px)
+                      instead of the default 2.5.8 (AA, 24x24px); focus
+                      indicators are also held to 2.4.13 (AAA, minimum
+                      thickness) alongside the default 1.4.11 (AA, contrast)
       --config <path>  Path to a tailwind.config.js/.cjs (v3) or a CSS
                         @theme file like app/globals.css (v4) to read
                         custom theme colors/spacing from (default:

--- a/packages/tailwind-a11y/src/index.ts
+++ b/packages/tailwind-a11y/src/index.ts
@@ -3,7 +3,12 @@ export { checkContrast, checkContrastValueSkips, suggestContrastFix, type Contra
 export { extractTouchTargetChecks, extractTouchTargetSkips, type TouchTargetCheck, type TouchTargetSkip } from "./parser/extractTouchTargets.js";
 export { checkTouchTargets, type TouchTargetViolation } from "./rules/checkTouchTarget.js";
 export { extractFocusIndicatorChecks, type FocusIndicatorCheck } from "./parser/extractFocusIndicators.js";
-export { checkFocusIndicators, type FocusIndicatorViolation } from "./rules/checkFocusIndicator.js";
+export {
+  checkFocusIndicators,
+  checkFocusContrast,
+  type FocusIndicatorViolation,
+  type FocusContrastViolation,
+} from "./rules/checkFocusIndicator.js";
 export { hexToRgb, contrastRatio, meetsWCAG, requiredRatio, type RGB } from "./contrast/luminance.js";
 export {
   resolveTheme,

--- a/packages/tailwind-a11y/src/parser/extractFocusIndicators.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractFocusIndicators.test.ts
@@ -6,8 +6,36 @@ describe("extractFocusIndicatorChecks", () => {
     const code = `const C = () => <button className="p-2 focus:outline-none focus:ring-2">x</button>;`;
     const checks = extractFocusIndicatorChecks(code, "fake.tsx");
     expect(checks).toEqual([
-      { file: "fake.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", "focus:ring-2"] },
+      {
+        file: "fake.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-2"],
+        bgClass: null,
+        bgSource: null,
+      },
     ]);
+  });
+
+  it("resolves bg from the element's own class", () => {
+    const code = `const C = () => <button className="bg-blue-500 focus:ring-2 focus:ring-white">x</button>;`;
+    const [check] = extractFocusIndicatorChecks(code, "fake.tsx");
+    expect(check.bgClass).toBe("bg-blue-500");
+    expect(check.bgSource).toBe("self");
+  });
+
+  it("falls back to the immediate parent's bg", () => {
+    const code = `const C = () => <div className="bg-blue-500"><button className="focus:ring-2 focus:ring-white">x</button></div>;`;
+    const [check] = extractFocusIndicatorChecks(code, "fake.tsx");
+    expect(check.bgClass).toBe("bg-blue-500");
+    expect(check.bgSource).toBe("parent");
+  });
+
+  it("leaves bgClass null when neither the element nor its parent has one", () => {
+    const code = `const C = () => <button className="focus:ring-2 focus:ring-white">x</button>;`;
+    const [check] = extractFocusIndicatorChecks(code, "fake.tsx");
+    expect(check.bgClass).toBeNull();
+    expect(check.bgSource).toBeNull();
   });
 
   it("collects focus-visible: classes too", () => {

--- a/packages/tailwind-a11y/src/parser/extractFocusIndicators.ts
+++ b/packages/tailwind-a11y/src/parser/extractFocusIndicators.ts
@@ -1,12 +1,23 @@
 import * as t from "@babel/types";
 import { getStaticClassName, parseJSX, traverse } from "./babelInterop.js";
 import { isInteractiveElement } from "./isInteractiveElement.js";
+import { lastColorToken } from "./extractClasses.js";
 
 export interface FocusIndicatorCheck {
   file: string;
   line: number;
   tagName: string;
   focusClasses: string[];
+  // Same-element-or-immediate-parent bg-* resolution, reusing exactly the
+  // model extractClasses.ts's extractChecks already uses for the text-
+  // contrast check. checkFocusIndicators (the 2.4.7 removal check) never
+  // reads these, so they're optional rather than forcing every existing
+  // test fixture in checkFocusIndicator.test.ts to grow two unused fields --
+  // only checkFocusContrast (1.4.11/2.4.13) reads them, and treats a
+  // missing/null value as "skip" (no background to compare against), not a
+  // guess.
+  bgClass?: string | null;
+  bgSource?: "self" | "parent" | null;
 }
 
 function focusScopedClasses(className: string): string[] {
@@ -37,11 +48,32 @@ export function extractFocusIndicatorChecks(code: string, filePath: string): Foc
       const focusClasses = focusScopedClasses(className);
       if (focusClasses.length === 0) return; // nothing under focus:/focus-visible: — not a candidate
 
+      const ownBg = lastColorToken(className, "bg");
+      let bgClass: string | null = ownBg;
+      let bgSource: "self" | "parent" | null = ownBg ? "self" : null;
+
+      if (!bgClass) {
+        // Only the immediate JSX parent, same limit as extractClasses.ts's
+        // own contrast resolution — no deeper ancestor walk, no
+        // cross-component resolution.
+        const parentNode = path.parentPath?.node;
+        if (parentNode && t.isJSXElement(parentNode)) {
+          const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
+          const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
+          if (parentBg) {
+            bgClass = parentBg;
+            bgSource = "parent";
+          }
+        }
+      }
+
       checks.push({
         file: filePath,
         line: opening.loc?.start.line ?? 0,
         tagName: t.isJSXIdentifier(opening.name) ? opening.name.name : "onClick-element",
         focusClasses,
+        bgClass,
+        bgSource,
       });
     },
   });

--- a/packages/tailwind-a11y/src/rules/checkContrast.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.ts
@@ -18,7 +18,10 @@ export interface ContrastViolation {
 }
 
 export function resolveColorValue(utilityClass: string, palette: Palette = defaultPalette): string | null {
-  const match = /^(?:text|bg)-(.+)$/.exec(utilityClass);
+  // outline/ring are here for checkFocusIndicator.ts's non-text-contrast
+  // check (WCAG 1.4.11/2.4.13) -- same palette/arbitrary-hex/semantic-color
+  // resolution as text/bg, just a different utility prefix.
+  const match = /^(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
   if (!match) return null;
   const token = match[1];
 

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { checkFocusIndicators } from "./checkFocusIndicator.js";
+import { checkFocusContrast, checkFocusIndicators } from "./checkFocusIndicator.js";
 import { extractFocusIndicatorChecks } from "../parser/extractFocusIndicators.js";
+import { defaultPalette } from "../theme/defaultPalette.js";
+import { mergePalette } from "../theme/loadCustomTheme.js";
 
 describe("checkFocusIndicators", () => {
   it("flags a bare focus:outline-none with nothing else", () => {
@@ -178,5 +180,262 @@ describe("checkFocusIndicators", () => {
     const violations = checkFocusIndicators(extractFocusIndicatorChecks(code, "fake.tsx"));
     expect(violations).toHaveLength(1);
     expect(violations[0].type).toBe("focus-indicator");
+  });
+});
+
+describe("checkFocusContrast", () => {
+  it("flags a low-contrast ring (blue-400 on blue-500, ~1.3:1) — the case checkFocusIndicators misses entirely", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-blue-400"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      type: "focus-contrast",
+      indicatorClass: "focus:ring-blue-400",
+      bgClass: "bg-blue-500",
+      required: 3,
+      level: "AA",
+    });
+    expect(violations[0].ratio).toBeLessThan(3);
+    expect(violations[0].thicknessPx).toBeUndefined();
+  });
+
+  it("passes a high-contrast ring (white on blue-500) by default", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-white"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("passes a high-contrast ring-2 under strict too (contrast and thickness both meet AAA)", () => {
+    const violations = checkFocusContrast(
+      [
+        {
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-white"],
+          bgClass: "bg-blue-500",
+          bgSource: "self",
+        },
+      ],
+      true
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("flags ring-1 under strict even though contrast passes — thickness is an independent requirement, not a stricter ratio", () => {
+    const violations = checkFocusContrast(
+      [
+        {
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          focusClasses: ["focus:outline-none", "focus:ring-1", "focus:ring-white"],
+          bgClass: "bg-blue-500",
+          bgSource: "self",
+        },
+      ],
+      true
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].ratio).toBeGreaterThanOrEqual(3); // contrast genuinely passes
+    expect(violations[0]).toMatchObject({
+      level: "AAA",
+      thicknessPx: 1,
+      requiredThicknessPx: 2,
+    });
+  });
+
+  it("does not flag ring-1 the same case by default (thickness is only assessed under strict)", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-1", "focus:ring-white"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("resolves contrast for a bare `ring` (no width digit) under strict, but never fabricates a thickness value", () => {
+    const violations = checkFocusContrast(
+      [
+        {
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          focusClasses: ["focus:outline-none", "focus:ring", "focus:ring-blue-400"],
+          bgClass: "bg-blue-500",
+          bgSource: "self",
+        },
+      ],
+      true
+    );
+    // contrast still fails (blue-400 on blue-500) and is reported; thickness
+    // is unresolvable for a bare `ring` (version-dependent, see
+    // checkFocusIndicator.ts) so it's simply absent, never asserted.
+    expect(violations).toHaveLength(1);
+    expect(violations[0].level).toBe("AA");
+    expect(violations[0].thicknessPx).toBeUndefined();
+    expect(violations[0].requiredThicknessPx).toBeUndefined();
+  });
+
+  it("skips when there's no resolvable background", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-blue-400"],
+        bgClass: null,
+        bgSource: null,
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("skips when there's no explicit outline-*/ring-* color (out of scope, not a false pass)", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:border-4", "focus:border-blue-400"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("does not mistake ring-offset-* for the ring's own color or width", () => {
+    const violations = checkFocusContrast(
+      [
+        {
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          focusClasses: [
+            "focus:outline-none",
+            "focus:ring-2",
+            "focus:ring-white",
+            "focus:ring-offset-2",
+            "focus:ring-offset-blue-400",
+          ],
+          bgClass: "bg-blue-500",
+          bgSource: "self",
+        },
+      ],
+      true
+    );
+    // ring-white/ring-2 (the real indicator) is well above 3:1 and exactly
+    // 2px -- passes. If ring-offset-blue-400 or ring-offset-2 were
+    // mistakenly read as the indicator's own color/width, this would either
+    // false-flag or resolve the wrong values.
+    expect(violations).toEqual([]);
+  });
+
+  it("last-token-wins across outline-* and ring-* together, not per-prefix", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        // outline-blue-400 (low contrast) written first, ring-white (high
+        // contrast) written after -- the later one in source order is what
+        // actually renders, so it should win over the ignored one.
+        focusClasses: ["focus:outline-none", "focus:outline-blue-400", "focus:ring-2", "focus:ring-white"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it("composes end-to-end with extractFocusIndicatorChecks", () => {
+    const code = `const C = () => <button className="bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400">x</button>;`;
+    const violations = checkFocusContrast(extractFocusIndicatorChecks(code, "fake.tsx"));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].type).toBe("focus-contrast");
+  });
+
+  describe("with a custom palette", () => {
+    // Same hex as the stock blue-400 (#60a5fa), so an invisible custom-
+    // themed ring must be caught the same way the stock blue-400 case is
+    // above -- a default-palette-only call would silently see "brand-400"
+    // as unresolvable and report nothing (a real gap this project's
+    // checkContrast/checkTouchTargets siblings already close via their own
+    // palette param).
+    const customPalette = mergePalette(defaultPalette, { brand: { "400": "#60a5fa" } });
+
+    it("resolves a custom-theme indicator color that a default-palette-only call would skip entirely", () => {
+      const noPalette = checkFocusContrast([
+        {
+          file: "f.tsx",
+          line: 1,
+          tagName: "button",
+          focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-brand-400"],
+          bgClass: "bg-blue-500",
+          bgSource: "self",
+        },
+      ]);
+      expect(noPalette).toEqual([]); // unresolvable without the custom palette -- silent skip, not a false pass
+
+      const withPalette = checkFocusContrast(
+        [
+          {
+            file: "f.tsx",
+            line: 1,
+            tagName: "button",
+            focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-brand-400"],
+            bgClass: "bg-blue-500",
+            bgSource: "self",
+          },
+        ],
+        false,
+        customPalette
+      );
+      expect(withPalette).toHaveLength(1);
+      expect(withPalette[0].ratio).toBeLessThan(3);
+    });
+
+    it("resolves a custom-theme background the same way", () => {
+      const customBgPalette = mergePalette(defaultPalette, { brand: { "500": "#1e3a8a" } }); // dark navy
+      const violations = checkFocusContrast(
+        [
+          {
+            file: "f.tsx",
+            line: 1,
+            tagName: "button",
+            focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-blue-400"],
+            bgClass: "bg-brand-500",
+            bgSource: "self",
+          },
+        ],
+        false,
+        customBgPalette
+      );
+      // blue-400 on a dark navy custom background is a real pass -- would be
+      // wrongly skipped (bg unresolvable) without the custom palette.
+      expect(violations).toEqual([]);
+    });
   });
 });

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
@@ -1,5 +1,9 @@
 import type { FocusIndicatorCheck } from "../parser/extractFocusIndicators.js";
 import { COLOR_TOKEN } from "../parser/extractClasses.js";
+import { resolveColorValue } from "./checkContrast.js";
+import { contrastRatio, hexToRgb } from "../contrast/luminance.js";
+import { defaultPalette } from "../theme/defaultPalette.js";
+import type { Palette } from "../theme/defaultPalette.js";
 
 export interface FocusIndicatorViolation {
   type: "focus-indicator";
@@ -107,6 +111,157 @@ export function checkFocusIndicators(checks: FocusIndicatorCheck[]): FocusIndica
       line: check.line,
       tagName: check.tagName,
       removalClass: removal,
+    });
+  }
+
+  return violations;
+}
+
+// --- Focus indicator contrast: WCAG 1.4.11 Non-text Contrast (AA) + 2.4.13
+// Focus Appearance (AAA, under strict) -------------------------------------
+//
+// checkFocusIndicators above only asks "was the outline removed with
+// nothing visible put back." It never looks at whether a present indicator
+// is actually *visible* -- a real, silent miss: `focus:outline
+// focus:outline-2 focus:outline-blue-400` on `bg-blue-500` reports zero
+// violations today, even though blue-400-on-blue-500 is nowhere near a
+// visible focus ring. 1.4.11 requires 3:1 contrast for UI-component state
+// indicators (explicitly including focus indicators, per the W3C
+// Understanding doc). 2.4.13 (AAA) does NOT raise that 3:1 -- it adds a
+// second, independent minimum-thickness requirement (>= a 2 CSS pixel
+// perimeter). `strict` here means "also enforce thickness," not "raise the
+// contrast bar" -- unlike touch-target's AA/AAA, which move along the same
+// axis, these are two different axes.
+
+export interface FocusContrastViolation {
+  type: "focus-contrast";
+  file: string;
+  line: number;
+  tagName: string;
+  indicatorClass: string;
+  bgClass: string;
+  ratio: number;
+  required: number;
+  // Reflects which SC this element actually fails, not just whether
+  // `strict` is on: a contrast-only failure is a real 1.4.11/AA violation
+  // whether or not strict is enabled, so it's always reported as "AA".
+  // Only a thickness failure (only ever assessed under strict) is "AAA".
+  level: "AA" | "AAA";
+  thicknessPx?: number;
+  requiredThicknessPx?: number;
+}
+
+// Flat non-text threshold -- not luminance.ts's requiredRatio()/meetsWCAG(),
+// which model the text-specific large-text/small-text AA/AAA table that
+// doesn't apply to UI-component contrast.
+const NON_TEXT_MIN_RATIO = 3;
+
+// WCAG 2.4.13's "2 CSS pixel thick perimeter" -- verified against a real
+// tailwindcss@4.3.3 compile (see CLAUDE.md) rather than assumed.
+const FOCUS_INDICATOR_MIN_THICKNESS_PX = 2;
+
+// outline-{0,1,2,4,8} / ring-{0,1,2,4,8} -- Tailwind's fixed width scale for
+// both utilities, verified against a real build. Bare `ring`/`outline` (no
+// digit) is deliberately NOT in this map: verified via that same build that
+// it resolves to 1px in Tailwind v4, but v3's bare `ring` default is
+// documented elsewhere as 3px -- a real cross-version difference this tool
+// can't currently distinguish, so bare ring/outline contributes color (if
+// paired with an explicit color utility) but never a thickness value.
+const WIDTH_SCALE: Record<string, number> = { "0": 0, "1": 1, "2": 2, "4": 4, "8": 8 };
+
+// Near-duplicate of extractClasses.ts's lastColorToken, not a call to it:
+// that function takes a single prefix ("text" | "bg") and this needs
+// last-token-wins across *two* prefixes (outline-*, ring-*) in one pass, so
+// whichever was actually written last in the class list wins regardless of
+// which utility it is. Reuses COLOR_TOKEN (the one shared "is this
+// color-shaped" test) and only excludes the "opacity" scale name locally --
+// lastColorToken's full NON_COLOR_SCALE_NAMES set also excludes
+// "linear"/"conic", but those are bg-gradient-angle utilities with no
+// outline-*/ring-* equivalent, so they can never appear here.
+function lastIndicatorColorToken(focusClasses: string[]): string | null {
+  let found: string | null = null;
+  for (const raw of focusClasses) {
+    const base = raw.slice(raw.lastIndexOf(":") + 1);
+    const match = /^(?:outline|ring)-(.+)$/.exec(base);
+    if (!match) continue;
+    const rest = match[1];
+    if (!COLOR_TOKEN.test(rest)) continue;
+    const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
+    if (scaleName === "opacity") continue;
+    found = base;
+  }
+  return found;
+}
+
+// Same last-token-wins-across-both-prefixes shape as above, but for width:
+// only an enumerated outline-{N}/ring-{N} or an arbitrary [Npx] sets a
+// thickness. A color token (ring-blue-400), ring-offset-*, ring-inset, etc.
+// don't match either shape and are silently ignored here -- they're a
+// different utility's job (color, offset, inset), not this one's.
+function lastIndicatorThicknessPx(focusClasses: string[]): number | null {
+  let found: number | null = null;
+  for (const raw of focusClasses) {
+    const base = raw.slice(raw.lastIndexOf(":") + 1);
+    const match = /^(?:outline|ring)-(.+)$/.exec(base);
+    if (!match) continue;
+    const token = match[1];
+    if (token in WIDTH_SCALE) {
+      found = WIDTH_SCALE[token];
+      continue;
+    }
+    const arbitrary = /^\[(\d+(?:\.\d+)?)px\]$/.exec(token);
+    if (arbitrary) found = Number(arbitrary[1]);
+  }
+  return found;
+}
+
+export function checkFocusContrast(
+  checks: FocusIndicatorCheck[],
+  strict = false,
+  palette: Palette = defaultPalette
+): FocusContrastViolation[] {
+  const violations: FocusContrastViolation[] = [];
+
+  for (const check of checks) {
+    if (!check.bgClass) continue; // no resolvable background — skip, not a guess
+
+    const indicatorBase = lastIndicatorColorToken(check.focusClasses);
+    if (!indicatorBase) continue; // no explicit outline-*/ring-* color — out of scope, see CLAUDE.md
+
+    const indicatorHex = resolveColorValue(indicatorBase, palette);
+    const bgHex = resolveColorValue(check.bgClass, palette);
+    if (!indicatorHex || !bgHex) continue; // custom theme color / unsupported arbitrary value — skip
+
+    const indicatorRgb = hexToRgb(indicatorHex);
+    const bgRgb = hexToRgb(bgHex);
+    if (!indicatorRgb || !bgRgb) continue;
+
+    const ratio = contrastRatio(indicatorRgb, bgRgb);
+    const contrastFails = ratio < NON_TEXT_MIN_RATIO;
+
+    let thicknessPx: number | null = null;
+    if (strict) thicknessPx = lastIndicatorThicknessPx(check.focusClasses);
+    const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
+
+    if (!contrastFails && !thicknessFails) continue;
+
+    const rawIndicatorClass = check.focusClasses.find(
+      (raw) => raw.slice(raw.lastIndexOf(":") + 1) === indicatorBase
+    )!;
+
+    violations.push({
+      type: "focus-contrast",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      indicatorClass: rawIndicatorClass,
+      bgClass: check.bgClass,
+      ratio,
+      required: NON_TEXT_MIN_RATIO,
+      level: thicknessFails ? "AAA" : "AA",
+      ...(thicknessFails && thicknessPx !== null
+        ? { thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX }
+        : {}),
     });
   }
 

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -1,6 +1,6 @@
 # Tailwind a11y
 
-Live WCAG diagnostics for Tailwind CSS, in the editor — the same three checks as
+Live WCAG diagnostics for Tailwind CSS, in the editor — the same checks as
 [`tailwind-a11y`](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y),
 its [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y),
 and its [GitHub Action](https://github.com/chamroro/tailwind-a11y/tree/main/packages/github-action-tailwind-a11y),
@@ -14,6 +14,7 @@ reimplemented here.
 | Contrast | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — with a suggested nearby shade |
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
+| Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
 (debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
@@ -31,7 +32,9 @@ setting:
 ```
 
 Set `tailwind-a11y.strict` to enforce the stricter 44×44px touch target
-minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA):
+minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA), and to
+also require focus indicators to meet WCAG 2.4.13's minimum thickness
+alongside the always-on 3:1 contrast check (1.4.11):
 
 ```json
 { "tailwind-a11y.strict": true }

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -41,7 +41,7 @@
           "type": "boolean",
           "default": false,
           "scope": "resource",
-          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px)."
+          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check."
         }
       }
     }
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.9.0"
+    "tailwind-a11y": "^0.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -6,6 +6,7 @@ import {
   checkTouchTargets,
   extractFocusIndicatorChecks,
   checkFocusIndicators,
+  checkFocusContrast,
   resolveTheme,
 } from "tailwind-a11y";
 import { formatViolation, type AnyViolation } from "./format.js";
@@ -89,10 +90,12 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
   // log is the same low-key channel the catch block below already uses.
   if (configError) console.error(`tailwind-a11y: ${configError}`);
 
+  const focusChecks = extractFocusIndicatorChecks(text, file);
   const violations: AnyViolation[] = [
     ...checkContrast(extractChecks(text, file), palette),
     ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing), strict),
-    ...checkFocusIndicators(extractFocusIndicatorChecks(text, file)),
+    ...checkFocusIndicators(focusChecks),
+    ...checkFocusContrast(focusChecks, strict, palette),
   ];
 
   return violations.map((v) => {

--- a/packages/vscode-tailwind-a11y/src/format.test.ts
+++ b/packages/vscode-tailwind-a11y/src/format.test.ts
@@ -76,4 +76,38 @@ describe("formatViolation", () => {
       "<button> removes the focus outline (focus:outline-none) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)"
     );
   });
+
+  it("formats a focus-contrast violation (contrast only, AA)", () => {
+    const message = formatViolation({
+      type: "focus-contrast",
+      file: "f.tsx",
+      line: 1,
+      tagName: "button",
+      indicatorClass: "focus:ring-blue-400",
+      bgClass: "bg-blue-500",
+      ratio: 1.45,
+      required: 3,
+      level: "AA",
+    });
+    expect(message).toBe("<button> focus indicator focus:ring-blue-400 on bg-blue-500 — ratio 1.45, needs 3 (WCAG 1.4.11)");
+  });
+
+  it("formats a strict-mode focus-contrast violation with a thickness failure (AAA)", () => {
+    const message = formatViolation({
+      type: "focus-contrast",
+      file: "f.tsx",
+      line: 1,
+      tagName: "button",
+      indicatorClass: "focus:ring-white",
+      bgClass: "bg-blue-500",
+      ratio: 3.68,
+      required: 3,
+      level: "AAA",
+      thicknessPx: 1,
+      requiredThicknessPx: 2,
+    });
+    expect(message).toBe(
+      "<button> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
+    );
+  });
 });

--- a/packages/vscode-tailwind-a11y/src/format.ts
+++ b/packages/vscode-tailwind-a11y/src/format.ts
@@ -1,6 +1,6 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation } from "tailwind-a11y";
+import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation;
+export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
 
 // Mirrors cli.ts's formatViolation, minus the leading "${line}: " prefix —
 // VS Code renders the diagnostic's location itself. Kept in its own module
@@ -18,5 +18,12 @@ export function formatViolation(v: AnyViolation): string {
     }
     case "focus-indicator":
       return `<${v.tagName}> removes the focus outline (${v.removalClass}) with no visible replacement (focus:ring-*/border-*/shadow-*/bg-*/outline-*)`;
+    case "focus-contrast": {
+      const sc = v.level === "AAA" ? "2.4.13" : "1.4.11";
+      const base = `<${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} — ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
+      return v.thicknessPx !== undefined
+        ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
+        : base;
+    }
   }
 }


### PR DESCRIPTION
## What

The focus-indicator check only ever asked "was the outline removed with nothing put back" -- it never looked at whether a present indicator is actually visible. `focus:outline focus:outline-2 focus:outline-blue-400` on `bg-blue-500` reported zero violations before this, even though blue-400-on-blue-500 is nowhere near a visible ring. This adds `checkFocusContrast()` as a second, independent check on the same `focus:`/`focus-visible:` classes, wired through all four adapters the same way the touch-target work landed: CLI `--strict`, a new `focus-contrast` ESLint rule with its own `strict` option, the VS Code `tailwind-a11y.strict` setting, and the GitHub Action `strict` input.

## Why two independent checks, not one stricter number

WCAG 1.4.11 (AA) requires 3:1 contrast for UI-component state indicators, explicitly including focus indicators, and is always enforced here. WCAG 2.4.13 (AAA), gated behind `strict`, does not raise that 3:1 -- it adds a second, independent minimum-thickness requirement (an indicator needs to be at least a 2 CSS pixel perimeter). A pure-contrast failure is always reported as AA even under `strict`; only a thickness failure is AAA. That's different from touch-target's AA/AAA, which move along the same axis (24px to 44px), so the `level` field here reflects which SC actually failed rather than just whether `strict` is on.

Scope is deliberately narrow: only an explicit `outline-{color}`/`ring-{color}` counts as "the indicator" -- `border-*`/`bg-*`/`shadow-*` replacements (valid for the existing removal check) aren't resolved for contrast. Bare `ring`/`outline` with no width digit never claims a thickness value either -- verified against a real Tailwind v4 compile that it resolves to 1px there, but v3's bare `ring` default is documented elsewhere as 3px, and guessing would silently be wrong for whichever version isn't the one guessed.

## Versions

Engine, eslint-plugin, and the GitHub Action go 0.9.0 -> 0.10.0. VS Code goes 0.10.0 -> 0.11.0, matching its usual one-ahead offset.

## Test plan

- [x] Full test suite passes across all four packages, including new custom-palette regression tests for the bug found in review
- [x] Manual CLI smoke tests: low-contrast ring flagged by default; high-contrast ring passes both modes; a high-contrast-but-1px ring passes by default and fails only under `--strict` (the two-independent-requirements case); a bare `ring` with an invisible color still gets flagged on contrast alone, with no fabricated thickness value
- [x] Confirmed end-to-end that a custom-themed invisible ring is silently skipped without a resolvable theme and correctly flagged once one resolves
- [x] GitHub Action bundle rebuilt and confirmed non-stale
- [x] Independent review pass, including a follow-up fix and re-verification after a real bug was found