### PR TITLE
Sync docs/descriptions with current check count and adapters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ packages/
 ```
 
 All adapters call the engine's `extract*`/`check*` functions directly —
-none of them reimplement detection logic. Adding another adapter (or a
-fourth check) should follow the same pattern.
+none of them reimplement detection logic. Adding another adapter (or
+another check) should follow the same pattern.
 
 ## Rules specific to the monorepo layout
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ they ship, instead of at a Lighthouse audit or QA pass.
 | [`vscode-tailwind-a11y`](./packages/vscode-tailwind-a11y) | Live editor diagnostics |
 | [`github-action-tailwind-a11y`](./packages/github-action-tailwind-a11y) | Inline PR annotations (`uses: chamroro/tailwind-a11y@v0`) |
 
-All four run the same three checks — color contrast (WCAG 1.4.3), touch target size
-(WCAG 2.5.8), and focus indicator removal (WCAG 2.4.7) — through one shared engine, so
-results never disagree between them. See each package's README for install and usage.
+All four run the same four checks — color contrast (WCAG 1.4.3), touch target size
+(WCAG 2.5.8, or 2.5.5 in strict mode), focus indicator removal (WCAG 2.4.7), and focus
+indicator contrast (WCAG 1.4.11, or also 2.4.13 in strict mode) — through one shared
+engine, so results never disagree between them. See each package's README for install
+and usage.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tailwind-a11y-monorepo",
   "version": "0.0.0",
   "private": true,
-  "description": "Monorepo for tailwind-a11y (WCAG static-analysis CLI for Tailwind class combinations) and its ESLint + VS Code adapters.",
+  "description": "Monorepo for tailwind-a11y (WCAG static-analysis CLI for Tailwind class combinations) and its ESLint, VS Code, and GitHub Action adapters.",
   "author": "chamroro",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
   "version": "0.10.0",
-  "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations.",
+  "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -120,8 +120,9 @@ Tailwind-class-level sizing or focus-style analysis).
   exposes it the same opt-in, default-off way: CLI `--strict`, ESLint
   `["error", { strict: true }]` rule option (the first rule option this
   plugin has ever needed — `configPath` deliberately lives in
-  `settings["tailwind-a11y"]` instead, since it's cross-cutting across all
-  three rules and `strict` isn't), VS Code `tailwind-a11y.strict` setting,
+  `settings["tailwind-a11y"]` instead, since it's shared by whichever rules
+  need theme resolution (contrast, touch-target, and now focus-contrast — see
+  below) and `strict` isn't), VS Code `tailwind-a11y.strict` setting,
   GitHub Action `strict` input. `TouchTargetViolation` carries the active
   threshold on the violation itself now (`required: number`, `level: "AA" |
   "AAA"`), mirroring `ContrastViolation`'s existing shape — every formatter

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tailwind-a11y",
   "version": "0.10.0",
-  "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal — in Tailwind CSS class combinations before they ship.",
+  "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {
     "tailwind-a11y": "./dist/cli.js"


### PR DESCRIPTION
Docs and package descriptions were out of sync with the current check count and adapter list. Synced them up

text only, no code changes.