### PR TITLE
Support OKLCH custom theme colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.10.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.11.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.11.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.12.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ they ship, instead of at a Lighthouse audit or QA pass.
 | [`vscode-tailwind-a11y`](./packages/vscode-tailwind-a11y) | Live editor diagnostics |
 | [`github-action-tailwind-a11y`](./packages/github-action-tailwind-a11y) | Inline PR annotations (`uses: chamroro/tailwind-a11y@v0`) |
 
-All four run the same four checks — color contrast (WCAG 1.4.3), touch target size
-(WCAG 2.5.8, or 2.5.5 in strict mode), focus indicator removal (WCAG 2.4.7), and focus
-indicator contrast (WCAG 1.4.11, or also 2.4.13 in strict mode) — through one shared
-engine, so results never disagree between them. See each package's README for install
-and usage.
+All four run the same five checks — color contrast (WCAG 1.4.3), touch target size
+(WCAG 2.5.8, or 2.5.5 in strict mode), focus indicator removal (WCAG 2.4.7), focus
+indicator contrast (WCAG 1.4.11, or also 2.4.13 in strict mode), and reduced motion for
+interaction-triggered animation (WCAG 2.3.3, strict-mode only — no AA tier exists) —
+through one shared engine, so results never disagree between them. See each package's
+README for install and usage.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,9 @@ inputs:
   strict:
     description: >-
       Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default
-      2.5.8 (AA, 24x24px).
+      2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness
+      alongside the always-on 1.4.11 (AA) contrast check, and the
+      reduced-motion check (WCAG 2.3.3, AAA-only, off by default).
     required: false
     default: "false"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,9 +1122,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,9 +1139,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1162,9 +1156,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,9 +1173,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1202,9 +1190,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,9 +1207,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4076,9 +4058,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4100,9 +4079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4124,9 +4100,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4148,9 +4121,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6487,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.10.0"
+        "tailwind-a11y": "^0.11.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6506,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.10.0"
+        "tailwind-a11y": "^0.11.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6520,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6544,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.10.0"
+        "tailwind-a11y": "^0.11.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -46,6 +46,7 @@ export default [
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |
+| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 
@@ -84,6 +85,26 @@ export default [
   },
 ];
 ```
+
+## Reduced motion (AAA-only, opt-in)
+
+`reduced-motion` has no AA tier to fall back to, so it isn't part of
+`configs.recommended` the way the other three rules are — enable it
+explicitly if you want it:
+
+```js
+export default [
+  ...tailwindA11y.configs.recommended,
+  {
+    files: ["**/*.jsx", "**/*.tsx"],
+    plugins: { "tailwind-a11y": tailwindA11y },
+    rules: { "tailwind-a11y/reduced-motion": "warn" },
+  },
+];
+```
+
+No `strict` option here (unlike `touch-target`/`focus-contrast`) — enabling
+the rule at all is already the opt-in gesture.
 
 ## Notes
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.10.0"
+    "tailwind-a11y": "^0.11.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.11.0"
+    "tailwind-a11y": "^0.12.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/index.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/index.ts
@@ -4,6 +4,7 @@ import contrast from "./rules/contrast.js";
 import touchTarget from "./rules/touch-target.js";
 import focusIndicator from "./rules/focus-indicator.js";
 import focusContrast from "./rules/focus-contrast.js";
+import reducedMotion from "./rules/reduced-motion.js";
 
 // `../package.json` resolves correctly from both `src/` (dev) and `dist/`
 // (published), so the plugin version can't drift from the package version.
@@ -21,6 +22,7 @@ const plugin: ESLint.Plugin = {
     "touch-target": touchTarget,
     "focus-indicator": focusIndicator,
     "focus-contrast": focusContrast,
+    "reduced-motion": reducedMotion,
   },
   configs: {},
 };
@@ -40,6 +42,12 @@ Object.assign(plugin.configs!, {
       // README for the TS-parser caveat.
       languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
       plugins: { "tailwind-a11y": plugin },
+      // reduced-motion is deliberately not included here: every other rule
+      // has an AA baseline `recommended` can reasonably assume most
+      // projects want, but WCAG 2.3.3 (what reduced-motion enforces) is
+      // AAA-only with no AA fallback -- silently bundling an AAA-only rule
+      // into "recommended" would surprise users who added this plugin
+      // expecting an AA floor. See README for enabling it explicitly.
       rules: {
         "tailwind-a11y/contrast": "error",
         "tailwind-a11y/touch-target": "error",

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import rule from "./reduced-motion.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run("reduced-motion", rule, {
+  valid: [
+    {
+      name: "a motion-reduce:transform-none guard passes",
+      filename: "Ok.jsx",
+      code: `export const Ok = () => <div className="transition-transform hover:scale-110 motion-reduce:transform-none">x</div>;`,
+    },
+    {
+      name: "a transition scoped under motion-safe: instead of unscoped passes",
+      filename: "Ok2.jsx",
+      code: `export const Ok = () => <div className="motion-safe:transition-transform hover:scale-110">x</div>;`,
+    },
+    {
+      name: "transition-colors doesn't animate transform, so no violation",
+      filename: "Colors.jsx",
+      code: `export const D = () => <div className="transition-colors hover:scale-110">x</div>;`,
+    },
+    {
+      name: "an identity-value interaction utility (scale-100) is not real motion",
+      filename: "Identity.jsx",
+      code: `export const D = () => <div className="transition-transform hover:scale-100">x</div>;`,
+    },
+  ],
+  invalid: [
+    {
+      name: "an unscoped transition-transform with an interaction-scoped scale and no guard is enabling this rule's opt-in, so it fires without a strict option",
+      filename: "Card.jsx",
+      code: `export const Card = () => <div className="transition-transform hover:scale-110">x</div>;`,
+      errors: [
+        {
+          message:
+            "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+  ],
+  assertionOptions: { requireLocation: true, requireMessage: true },
+});

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
@@ -1,0 +1,49 @@
+import type { Rule } from "eslint";
+import { extractReducedMotionChecks, checkReducedMotion } from "tailwind-a11y";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce WCAG 2.3.3 AAA -- interaction-triggered transform animation (scale/rotate/translate/skew under hover:/focus:/active:) must be disableable via prefers-reduced-motion",
+      recommended: true,
+      url: "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#reduced-motion",
+    },
+    // No AA tier to fall back to for this SC, unlike touch-target/
+    // focus-contrast -- no strict option, same schema: [] as the original
+    // focus-indicator rule. checkReducedMotion() itself defaults to
+    // reporting nothing unless told `strict` (the CLI/VS Code/GitHub Action
+    // gate this behind --strict/tailwind-a11y.strict/INPUT_STRICT, since
+    // those tools scan everything by default and an AAA-only check
+    // shouldn't silently start failing existing users' CI on upgrade) --
+    // here, enabling this rule at all is already that opt-in gesture, so
+    // this is the one caller that always passes `true`.
+    schema: [],
+    messages: {
+      reducedMotion:
+        "<{{tagName}}> animates {{motionClass}} via {{transitionClass}} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+    },
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const violations = checkReducedMotion(
+          extractReducedMotionChecks(context.sourceCode.getText(), context.filename),
+          true
+        );
+
+        for (const v of violations) {
+          context.report({
+            loc: { line: v.line, column: 0 },
+            messageId: "reducedMotion",
+            data: { tagName: v.tagName, motionClass: v.motionClass, transitionClass: v.transitionClass },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -30,7 +30,7 @@ found (configurable below).
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
 | `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
-| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check |
+| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check, and the reduced-motion check (WCAG 2.3.3, AAA-only, off by default) |
 
 ```yaml
 - uses: chamroro/tailwind-a11y@v0

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -2647,8 +2647,8 @@ var require_parse2 = __commonJS({
             brace.value = brace.output = "\\{";
             value = output = "\\}";
             state.output = out;
-            for (const t6 of toks) {
-              state.output += t6.output || t6.value;
+            for (const t7 of toks) {
+              state.output += t7.output || t7.value;
             }
           }
           push({ type: "brace", value, output });
@@ -5974,7 +5974,7 @@ var require_generated = __commonJS({
     exports2.isJSXEmptyExpression = isJSXEmptyExpression;
     exports2.isJSXExpressionContainer = isJSXExpressionContainer;
     exports2.isJSXFragment = isJSXFragment2;
-    exports2.isJSXIdentifier = isJSXIdentifier5;
+    exports2.isJSXIdentifier = isJSXIdentifier6;
     exports2.isJSXMemberExpression = isJSXMemberExpression;
     exports2.isJSXNamespacedName = isJSXNamespacedName;
     exports2.isJSXOpeningElement = isJSXOpeningElement;
@@ -6959,7 +6959,7 @@ var require_generated = __commonJS({
       if (node.type !== "JSXSpreadChild") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
     }
-    function isJSXIdentifier5(node, opts) {
+    function isJSXIdentifier6(node, opts) {
       if (!node) return false;
       if (node.type !== "JSXIdentifier") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
@@ -19848,12 +19848,12 @@ var require_lib4 = __commonJS({
     });
     function _objectWithoutPropertiesLoose(r, e) {
       if (null == r) return {};
-      var t6 = {};
+      var t7 = {};
       for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
         if (-1 !== e.indexOf(n)) continue;
-        t6[n] = r[n];
+        t7[n] = r[n];
       }
-      return t6;
+      return t7;
     }
     var Position = class {
       constructor(line, col, index) {
@@ -28456,7 +28456,7 @@ var require_lib4 = __commonJS({
       }
       tsParseTypeOrTypePredicateAnnotation(returnToken) {
         return this.tsInType(() => {
-          const t6 = this.startNode();
+          const t7 = this.startNode();
           this.expect(returnToken);
           const node = this.startNode();
           const asserts = !!this.tsTryParse(this.tsParseTypePredicateAsserts.bind(this));
@@ -28471,26 +28471,26 @@ var require_lib4 = __commonJS({
               this.resetStartLocationFromNode(thisTypePredicate, node);
               thisTypePredicate.asserts = true;
             }
-            t6.typeAnnotation = thisTypePredicate;
-            return this.finishNode(t6, "TSTypeAnnotation");
+            t7.typeAnnotation = thisTypePredicate;
+            return this.finishNode(t7, "TSTypeAnnotation");
           }
           const typePredicateVariable = this.tsIsIdentifier() && this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
           if (!typePredicateVariable) {
             if (!asserts) {
-              return this.tsParseTypeAnnotation(false, t6);
+              return this.tsParseTypeAnnotation(false, t7);
             }
             node.parameterName = this.parseIdentifier();
             node.asserts = asserts;
             node.typeAnnotation = null;
-            t6.typeAnnotation = this.finishNode(node, "TSTypePredicate");
-            return this.finishNode(t6, "TSTypeAnnotation");
+            t7.typeAnnotation = this.finishNode(node, "TSTypePredicate");
+            return this.finishNode(t7, "TSTypeAnnotation");
           }
           const type = this.tsParseTypeAnnotation(false);
           node.parameterName = typePredicateVariable;
           node.typeAnnotation = type;
           node.asserts = asserts;
-          t6.typeAnnotation = this.finishNode(node, "TSTypePredicate");
-          return this.finishNode(t6, "TSTypeAnnotation");
+          t7.typeAnnotation = this.finishNode(node, "TSTypePredicate");
+          return this.finishNode(t7, "TSTypeAnnotation");
         });
       }
       tsTryParseTypeOrTypePredicateAnnotation() {
@@ -28529,12 +28529,12 @@ var require_lib4 = __commonJS({
         }
         return true;
       }
-      tsParseTypeAnnotation(eatColon = true, t6 = this.startNode()) {
+      tsParseTypeAnnotation(eatColon = true, t7 = this.startNode()) {
         this.tsInType(() => {
           if (eatColon) this.expect(14);
-          t6.typeAnnotation = this.tsParseType();
+          t7.typeAnnotation = this.tsParseType();
         });
-        return this.finishNode(t6, "TSTypeAnnotation");
+        return this.finishNode(t7, "TSTypeAnnotation");
       }
       tsParseType() {
         assert(this.state.inType);
@@ -30515,7 +30515,7 @@ var require_lib4 = __commonJS({
           }
           const topicToken = pluginsMap.get("pipelineOperator").topicToken;
           if (!TOPIC_TOKENS.includes(topicToken)) {
-            const tokenList = TOPIC_TOKENS.map((t6) => `"${t6}"`).join(", ");
+            const tokenList = TOPIC_TOKENS.map((t7) => `"${t7}"`).join(", ");
             throw new Error(`"pipelineOperator" in "proposal": "hack" mode also requires a "topicToken" option whose value must be one of: ${tokenList}.`);
           }
           if (topicToken === "#" && ((_pluginsMap$get = pluginsMap.get("recordAndTuple")) == null ? void 0 : _pluginsMap$get.syntaxType) === "hash") {
@@ -35241,7 +35241,7 @@ var require_virtual_types_validator = __commonJS({
       isIdentifier,
       isImportDeclaration,
       isImportSpecifier,
-      isJSXIdentifier: isJSXIdentifier5,
+      isJSXIdentifier: isJSXIdentifier6,
       isJSXMemberExpression,
       isMemberExpression,
       isRestElement: nodeIsRestElement,
@@ -35263,7 +35263,7 @@ var require_virtual_types_validator = __commonJS({
       } = this;
       if (isIdentifier(node, opts)) {
         return nodeIsReferenced(node, parent, this.parentPath.parent);
-      } else if (isJSXIdentifier5(node, opts)) {
+      } else if (isJSXIdentifier6(node, opts)) {
         if (!isJSXMemberExpression(parent) && isCompatTag(node.name)) return false;
         return nodeIsReferenced(node, parent, this.parentPath.parent);
       } else {
@@ -35634,8 +35634,8 @@ var require_renamer = __commonJS({
       value: true
     });
     exports2.default = void 0;
-    var t6 = require_lib3();
-    var _t = t6;
+    var t7 = require_lib3();
+    var _t = t7;
     var _traverseNode = require_traverse_node();
     var _visitors = require_visitors();
     var _context = require_context2();
@@ -35701,7 +35701,7 @@ var require_renamer = __commonJS({
           const {
             declaration
           } = maybeExportDeclar.node;
-          if (t6.isDeclaration(declaration) && !declaration.id) {
+          if (t7.isDeclaration(declaration) && !declaration.id) {
             return;
           }
         }
@@ -35737,11 +35737,11 @@ var require_renamer = __commonJS({
         const skipKeys = {
           discriminant: true
         };
-        if (t6.isMethod(blockToTraverse)) {
+        if (t7.isMethod(blockToTraverse)) {
           if (blockToTraverse.computed) {
             skipKeys.key = true;
           }
-          if (!t6.isObjectMethod(blockToTraverse)) {
+          if (!t7.isObjectMethod(blockToTraverse)) {
             skipKeys.decorators = true;
           }
         }
@@ -36048,7 +36048,7 @@ var require_scope = __commonJS({
     var _traverseForScope = require_traverseForScope();
     var _binding = require_binding();
     var _t = require_lib3();
-    var t6 = _t;
+    var t7 = _t;
     var _cache = require_cache();
     var globalsBuiltinLower = require_builtin_lower();
     var globalsBuiltinUpper = require_builtin_upper();
@@ -36253,7 +36253,7 @@ var require_scope = __commonJS({
         parent.registerDeclaration(path);
       },
       ReferencedIdentifier(path, state) {
-        if (t6.isTSQualifiedName(path.parent) && path.parent.right === path.node) {
+        if (t7.isTSQualifiedName(path.parent) && path.parent.right === path.node) {
           return;
         }
         if (path.parentPath.isTSImportEqualsDeclaration()) return;
@@ -36673,7 +36673,7 @@ var require_scope = __commonJS({
         } else if (isCallExpression(node)) {
           return matchesPattern(node.callee, "Symbol.for") && !this.hasBinding("Symbol", {
             noGlobals: true
-          }) && node.arguments.length === 1 && t6.isStringLiteral(node.arguments[0]);
+          }) && node.arguments.length === 1 && t7.isStringLiteral(node.arguments[0]);
         } else {
           return isPureish(node);
         }
@@ -40179,7 +40179,7 @@ var require_typescript2 = __commonJS({
       this.tokenChar(60);
       let printTrailingSeparator = parent.type === "ArrowFunctionExpression" && node.params.length === 1;
       if (this.tokenMap && node.start != null && node.end != null) {
-        printTrailingSeparator && (printTrailingSeparator = !!this.tokenMap.find(node, (t6) => this.tokenMap.matchesOriginal(t6, ",")));
+        printTrailingSeparator && (printTrailingSeparator = !!this.tokenMap.find(node, (t7) => this.tokenMap.matchesOriginal(t7, ",")));
         printTrailingSeparator || (printTrailingSeparator = this.shouldPrintTrailingComma(">"));
       }
       this.printList(node.params, printTrailingSeparator);
@@ -45141,7 +45141,7 @@ var require_removal = __commonJS({
     var _cache = require_cache();
     var _replacement = require_replacement();
     var _index = require_path2();
-    var t6 = require_lib3();
+    var t7 = require_lib3();
     var _modification = require_modification();
     var _context = require_context2();
     function remove() {
@@ -45160,7 +45160,7 @@ var require_removal = __commonJS({
       _markRemoved.call(this);
     }
     function _removeFromScope() {
-      const bindings = t6.getBindingIdentifiers(this.node, false, false, true);
+      const bindings = t7.getBindingIdentifiers(this.node, false, false, true);
       Object.keys(bindings).forEach((name) => this.scope.removeBinding(name));
     }
     function _callRemovalHooks() {
@@ -46326,12 +46326,12 @@ var require_options = __commonJS({
     var _excluded = ["placeholderWhitelist", "placeholderPattern", "preserveComments", "syntacticPlaceholders"];
     function _objectWithoutPropertiesLoose(r, e) {
       if (null == r) return {};
-      var t6 = {};
+      var t7 = {};
       for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
         if (-1 !== e.indexOf(n)) continue;
-        t6[n] = r[n];
+        t7[n] = r[n];
       }
-      return t6;
+      return t7;
     }
     function merge(a, b) {
       const {
@@ -46411,7 +46411,7 @@ var require_parse3 = __commonJS({
       isExpressionStatement,
       isFunction,
       isIdentifier,
-      isJSXIdentifier: isJSXIdentifier5,
+      isJSXIdentifier: isJSXIdentifier6,
       isNewExpression,
       isPlaceholder,
       isStatement,
@@ -46462,7 +46462,7 @@ var require_parse3 = __commonJS({
         hasSyntacticPlaceholders = true;
       } else if (hasSyntacticPlaceholders || state.syntacticPlaceholders) {
         return;
-      } else if (isIdentifier(node) || isJSXIdentifier5(node)) {
+      } else if (isIdentifier(node) || isJSXIdentifier6(node)) {
         name = node.name;
       } else if (isStringLiteral2(node)) {
         name = node.value;
@@ -48325,7 +48325,7 @@ var require_path2 = __commonJS({
     var _index = require_lib8();
     var _index2 = require_scope();
     var _t = require_lib3();
-    var t6 = _t;
+    var t7 = _t;
     var cache = require_cache();
     var _generator = require_lib5();
     var NodePath_ancestry = require_ancestry();
@@ -48586,9 +48586,9 @@ var require_path2 = __commonJS({
       _getKey: NodePath_family._getKey,
       _getPattern: NodePath_family._getPattern
     });
-    for (const type of t6.TYPES) {
+    for (const type of t7.TYPES) {
       const typeKey = `is${type}`;
-      const fn = t6[typeKey];
+      const fn = t7[typeKey];
       NodePath_Final.prototype[typeKey] = function(opts) {
         return fn(this.node, opts);
       };
@@ -48601,7 +48601,7 @@ var require_path2 = __commonJS({
     Object.assign(NodePath_Final.prototype, NodePath_virtual_types_validator);
     for (const type of Object.keys(virtualTypes)) {
       if (type.startsWith("_")) continue;
-      if (!t6.TYPES.includes(type)) t6.TYPES.push(type);
+      if (!t7.TYPES.includes(type)) t7.TYPES.push(type);
     }
   }
 });
@@ -48824,7 +48824,7 @@ var require_context2 = __commonJS({
     var _traverseNode = require_traverse_node();
     var _index = require_path2();
     var _removal = require_removal();
-    var t6 = require_lib3();
+    var t7 = require_lib3();
     function call(key) {
       const opts = this.opts;
       this.debug(key);
@@ -49027,7 +49027,7 @@ var require_context2 = __commonJS({
         context,
         node
       } = this;
-      if (!t6.isPrivate(node) && node.computed) {
+      if (!t7.isPrivate(node) && node.computed) {
         context.maybeQueue(this.get("key"));
       }
       if (node.decorators) {
@@ -50009,6 +50009,114 @@ function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
   return violations;
 }
 
+// ../tailwind-a11y/dist/parser/extractReducedMotion.js
+var t6 = __toESM(require_lib3(), 1);
+var TRANSITION_BASES = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
+var INTERACTION_VARIANTS = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+function baseUtility2(raw) {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+function variantSegments(raw) {
+  return raw.split(":").slice(0, -1);
+}
+function extractReducedMotionChecks(code, filePath) {
+  const ast = parseJSX(code, filePath);
+  if (!ast)
+    return [];
+  const checks = [];
+  traverse(ast, {
+    JSXElement(path) {
+      const opening = path.node.openingElement;
+      const className = getStaticClassName(opening.attributes);
+      if (!className)
+        return;
+      const classes = className.split(/\s+/).filter(Boolean);
+      const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility2(raw)));
+      const hasInteractionClass = classes.some((raw) => variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v)));
+      if (!hasTransitionBase || !hasInteractionClass)
+        return;
+      checks.push({
+        file: filePath,
+        line: opening.loc?.start.line ?? 0,
+        tagName: t6.isJSXIdentifier(opening.name) ? opening.name.name : "unknown-element",
+        classes
+      });
+    }
+  });
+  return checks;
+}
+
+// ../tailwind-a11y/dist/rules/checkReducedMotion.js
+var TRANSITION_BASES2 = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
+var INTERACTION_VARIANTS2 = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+function baseUtility3(raw) {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+function variantSegments2(raw) {
+  return raw.split(":").slice(0, -1);
+}
+var SCALE_RE = /^(scale|scale-x|scale-y)-(\d+)$/;
+var ROTATE_RE = /^-?rotate-(\d+(?:\.\d+)?)$/;
+var TRANSLATE_RE = /^-?(translate-x|translate-y)-(\d+(?:\.\d+)?)$/;
+var SKEW_RE = /^-?(skew-x|skew-y)-(\d+(?:\.\d+)?)$/;
+function isNonIdentityMotionUtility(base) {
+  const scale = SCALE_RE.exec(base);
+  if (scale)
+    return Number(scale[2]) !== 100;
+  const rotate = ROTATE_RE.exec(base);
+  if (rotate)
+    return Number(rotate[1]) !== 0;
+  const translate = TRANSLATE_RE.exec(base);
+  if (translate)
+    return Number(translate[2]) !== 0;
+  const skew = SKEW_RE.exec(base);
+  if (skew)
+    return Number(skew[2]) !== 0;
+  return false;
+}
+function checkReducedMotion(checks, strict = false) {
+  if (!strict)
+    return [];
+  const violations = [];
+  for (const check of checks) {
+    let unscopedTransition = null;
+    let hasMotionReduceGuard = false;
+    for (const raw of check.classes) {
+      const base = baseUtility3(raw);
+      const segments = variantSegments2(raw);
+      if (segments.length === 0 && TRANSITION_BASES2.has(base))
+        unscopedTransition = raw;
+      if (segments.includes("motion-reduce") && (base === "transition-none" || base === "transform-none")) {
+        hasMotionReduceGuard = true;
+      }
+    }
+    if (!unscopedTransition)
+      continue;
+    if (hasMotionReduceGuard)
+      continue;
+    const motionClass = check.classes.find((raw) => {
+      const segments = variantSegments2(raw);
+      if (segments.includes("motion-safe"))
+        return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS2.has(v)))
+        return false;
+      return isNonIdentityMotionUtility(baseUtility3(raw));
+    });
+    if (!motionClass)
+      continue;
+    violations.push({
+      type: "reduced-motion",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      transitionClass: unscopedTransition,
+      motionClass,
+      level: "AAA"
+    });
+  }
+  return violations;
+}
+
 // ../tailwind-a11y/dist/theme/loadCustomTheme.js
 var import_node_fs = require("node:fs");
 var import_node_path = require("node:path");
@@ -50318,6 +50426,8 @@ function formatViolation(v) {
       const base = `<${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} \u2014 ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
       return v.thicknessPx !== void 0 ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px` : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard \u2014 WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 function toAnnotationCommand(v) {
@@ -50362,7 +50472,8 @@ async function main() {
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${err.message}`);

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49236,6 +49236,10 @@ function hexToRgb(hex) {
     b: parseInt(digits.slice(4, 6), 16)
   };
 }
+function rgbToHex(rgb) {
+  const channel = (c) => Math.round(Math.min(255, Math.max(0, c))).toString(16).padStart(2, "0");
+  return `#${channel(rgb.r)}${channel(rgb.g)}${channel(rgb.b)}`;
+}
 function applyAlpha(fg2, alpha, bg) {
   return {
     r: Math.round(alpha * fg2.r + (1 - alpha) * bg.r),
@@ -50010,6 +50014,42 @@ var import_node_fs = require("node:fs");
 var import_node_path = require("node:path");
 var import_node_module = require("node:module");
 
+// ../tailwind-a11y/dist/contrast/oklch.js
+var NUM = String.raw`\d+(?:\.\d+)?|\.\d+`;
+var OKLCH_RE = new RegExp(`^oklch\\(\\s*(${NUM})(%)?\\s+(${NUM})(%)?\\s+(${NUM})(deg)?\\s*\\)$`);
+function gammaEncode(linear) {
+  const clamped = Math.min(1, Math.max(0, linear));
+  return clamped <= 31308e-7 ? 12.92 * clamped : 1.055 * clamped ** (1 / 2.4) - 0.055;
+}
+function oklchToRgb(value) {
+  const match = OKLCH_RE.exec(value.trim());
+  if (!match)
+    return null;
+  const [, lRaw, lPct, cRaw, cPct, hRaw] = match;
+  const L = lPct ? Number(lRaw) / 100 : Number(lRaw);
+  const C = cPct ? Number(cRaw) / 100 * 0.4 : Number(cRaw);
+  const H = Number(hRaw);
+  if (!Number.isFinite(L) || !Number.isFinite(C) || !Number.isFinite(H))
+    return null;
+  const hRad = H * Math.PI / 180;
+  const a = C * Math.cos(hRad);
+  const b = C * Math.sin(hRad);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ ** 3;
+  const m = m_ ** 3;
+  const s = s_ ** 3;
+  const rLin = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const gLin = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const bLin = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
+  return {
+    r: Math.round(gammaEncode(rLin) * 255),
+    g: Math.round(gammaEncode(gLin) * 255),
+    b: Math.round(gammaEncode(bLin) * 255)
+  };
+}
+
 // ../tailwind-a11y/dist/theme/themeValueParsers.js
 var SPACING_RE = /^-?[\d.]+(rem|px)$/;
 function parseSpacingValue(value) {
@@ -50021,6 +50061,12 @@ function parseSpacingValue(value) {
   const num = parseFloat(value);
   return match[1] === "rem" ? num * 16 : num;
 }
+function resolveShadeHex(shadeValue) {
+  if (hexToRgb(shadeValue) !== null)
+    return shadeValue;
+  const oklchRgb = oklchToRgb(shadeValue);
+  return oklchRgb ? rgbToHex(oklchRgb) : null;
+}
 function parseColorScale(value) {
   if (typeof value !== "object" || value === null || Array.isArray(value))
     return null;
@@ -50030,9 +50076,10 @@ function parseColorScale(value) {
       continue;
     if (typeof shadeValue !== "string")
       continue;
-    if (hexToRgb(shadeValue) === null)
+    const hex = resolveShadeHex(shadeValue);
+    if (hex === null)
       continue;
-    shades[shade] = shadeValue;
+    shades[shade] = hex;
   }
   return Object.keys(shades).length > 0 ? shades : null;
 }

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.11.0",
+    "tailwind-a11y": "^0.12.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.10.0",
+    "tailwind-a11y": "^0.11.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/src/annotations.test.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.test.ts
@@ -110,6 +110,21 @@ describe("formatViolation", () => {
       "<a> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
     );
   });
+
+  it("formats a reduced-motion violation", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      file: "src/Card.tsx",
+      line: 3,
+      tagName: "div",
+      transitionClass: "transition-transform",
+      motionClass: "hover:scale-110",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
 });
 
 describe("toAnnotationCommand", () => {

--- a/packages/github-action-tailwind-a11y/src/annotations.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.ts
@@ -1,6 +1,17 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
+import type {
+  ContrastViolation,
+  TouchTargetViolation,
+  FocusIndicatorViolation,
+  FocusContrastViolation,
+  ReducedMotionViolation,
+} from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+export type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 // GitHub renders roughly 10 annotations per type per step (and ~50 per job) --
 // undocumented, observed limits. Correctness never rides on annotations:
@@ -42,6 +53,8 @@ export function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 

--- a/packages/github-action-tailwind-a11y/src/main.ts
+++ b/packages/github-action-tailwind-a11y/src/main.ts
@@ -9,6 +9,8 @@ import {
   extractFocusIndicatorChecks,
   checkFocusIndicators,
   checkFocusContrast,
+  extractReducedMotionChecks,
+  checkReducedMotion,
   resolveTheme,
 } from "tailwind-a11y";
 import { parseInputs } from "./inputs.js";
@@ -64,7 +66,8 @@ async function main(): Promise<void> {
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${(err as Error).message}`);

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -12,7 +12,8 @@ published consumers, not free pre-launch churn.)
 
 A static analysis CLI that catches WCAG accessibility violations in Tailwind
 CSS class combinations before they ship: color contrast, touch target size,
-and focus indicator removal/contrast. Existing contrast tools (e.g.
+focus indicator removal/contrast, and reduced motion for interaction-
+triggered animation. Existing contrast tools (e.g.
 `tailwindcss-contrast-checker`) only catch `text-*`/`bg-*` on the *same*
 element; this tool also catches the much more common **direct-parent**
 pattern:
@@ -225,6 +226,80 @@ Tailwind-class-level sizing or focus-style analysis).
     independently-configurable `strict` rule option (own file, own schema),
     since ESLint has no plugin-wide toggle and each rule's options are
     already independently set.
+- **Reduced motion: `checkReducedMotion(checks, strict?)` is WCAG 2.3.3
+  (AAA), the first check in this project with no AA tier to fall back to at
+  all.** Verified against the W3C Understanding doc that "motion animation"
+  specifically means a change to an element's perceived size, shape, or
+  position — color/opacity/blur changes don't qualify, even though they're
+  visually "animated" in the everyday sense. This is why `animate-spin`/
+  `-ping`/`-pulse`/`-bounce` are deliberately **not** covered here: they're
+  continuous, not interaction-triggered, so they belong under 2.2.2 (Pause,
+  Stop, Hide) instead, which has a materially different, harder-to-
+  statically-verify requirement (a 5-second-or-longer duration threshold
+  this tool has no way to know) — folding them in here would misattribute
+  the wrong SC. **Known gap, not yet closed**: that reasoning only holds for
+  an *unscoped* `animate-*` (always running). An interaction-scoped one
+  (`hover:animate-bounce` — a translateY-based, genuinely position-changing
+  animation per the Understanding doc's own definition, triggered only by
+  hover) is squarely 2.3.3's territory per the doc's own "not in response to
+  an intentional user activation" distinction for 2.2.2 — caught in
+  independent review, not yet implemented. The extractor's candidacy gate
+  requires a `transition`/`transition-all`/`transition-transform` base,
+  which `animate-*` isn't, so `hover:animate-bounce` alone currently
+  produces zero checks in any mode, not by deliberate design for this
+  specific case. Would need its own detection path (`animate-*` utilities
+  don't need a `transition-*` base to animate — they carry their own
+  `animation` property), not an extension of the transition-based logic
+  here.
+  - Because there's no AA tier, this is gated behind `strict` in every
+    scan-everything-by-default adapter (CLI, VS Code, GitHub Action) — an
+    AAA-only check running unconditionally would silently start failing
+    existing users' CI on a routine upgrade, unlike the genuinely-AA
+    `checkFocusIndicators` (2.4.7), the one other check in this file with no
+    strict tier. The ESLint rule is the one exception: enabling
+    `tailwind-a11y/reduced-motion` in a config is itself the opt-in
+    gesture, so it always checks for real (`schema: []`, no option, same as
+    `focus-indicator.ts`) — and it's deliberately **not** included in
+    `configs.recommended` either, for the same "AAA shouldn't silently ride
+    along with an AA baseline" reason.
+  - Not scoped to `isInteractiveElement()` — the Understanding doc's own
+    examples aren't limited to buttons/links (a plain hover-animated `<div>`
+    card is exactly the target case), so it walks every JSX element with a
+    static `className`, same as `extractClasses.ts`'s contrast check.
+    Interaction variants recognized: `hover`/`focus`/`focus-visible`/
+    `focus-within`/`active`.
+  - Variant detection scans **every** segment of a stacked variant class
+    (`variantSegments()`), not just the one immediately before the base
+    utility — caught in independent review: `motion-safe:hover:scale-110`
+    and `hover:motion-safe:scale-110` compile to the identical nested media
+    query (verified against a real v4 build), so checking only the
+    innermost segment made the original implementation order-dependent —
+    it recognized the interaction variant, or a `motion-safe:` self-guard on
+    the motion utility itself, only when written last, silently missing the
+    equally valid reverse ordering. Fixed by checking membership across the
+    whole variant stack instead of a single position, in both the extractor
+    and the rule.
+  - Only `transition`/`transition-all`/`transition-transform` count as a
+    qualifying transition base — verified against a real Tailwind v4 build
+    that these three are the only ones whose `transition-property` list
+    includes `transform`/`translate`/`scale`/`rotate`; `transition-colors`/
+    `-opacity`/`-shadow` don't, so a `scale-*` change under `hover:` on an
+    element with only one of those never actually animates (nothing tells
+    the browser to transition that property), and correctly isn't flagged.
+    The transition must be **unscoped** (not itself behind `hover:`/etc.) —
+    a variant-scoped transition isn't present in the resting state, so the
+    browser has nothing to transition from when the interaction begins.
+  - `motion-safe:`-scoping the transition instead of leaving it unscoped is
+    treated as a complete, alternative way of satisfying 2.3.3 (one of the
+    three approaches the Understanding doc names), not a partial one — the
+    transition simply doesn't exist unless motion is already safe.
+  - Each transform utility's identity value is excluded (`scale-100`,
+    `rotate-0`, `translate-x-0`/`-y-0`, `skew-x-0`/`-y-0`, either sign) —
+    real utilities that move nothing, the same "shape looks real but isn't"
+    failure class noted below. Arbitrary bracket values (`scale-[1.5]`) and
+    3D transform utilities (`rotate-x-*`, `translate-z-*`, confirmed to
+    exist in a real v4 build) are out of scope for v1 — unmatched, so
+    silently not considered "motion" rather than guessed at.
 - **Contrast: opacity modifiers (`text-gray-400/50`) are resolved on the
   *text* side only**, composited against the already-resolved (fully opaque)
   background — see `resolveTextColorWithOpacity()`/`applyAlpha()` in
@@ -277,6 +352,7 @@ src/
   parser/extractClasses.ts        — text-*/bg-* pairs per element (contrast)
   parser/extractTouchTargets.ts   — w-*/h-* pairs on interactive elements
   parser/extractFocusIndicators.ts— focus:/focus-visible: classes on interactive elements
+  parser/extractReducedMotion.ts  — transition + hover:/focus:/active: classes on any element
   rules/checkContrast.ts          — contrast violations (WCAG 1.4.3, AA);
                                      resolves a text-side opacity modifier
                                      against the resolved (opaque) bg; also
@@ -288,7 +364,9 @@ src/
   rules/checkFocusIndicator.ts    — focus indicator removal (WCAG 2.4.7, AA)
                                      and focus indicator contrast (WCAG
                                      1.4.11 AA / 2.4.13 AAA under strict)
-  cli.ts                         — fast-glob scan, run all four checkers,
+  rules/checkReducedMotion.ts     — reduced motion violations (WCAG 2.3.3,
+                                     AAA-only, gated behind strict)
+  cli.ts                         — fast-glob scan, run all five checkers,
                                     print report, exit 1 on any violations (CI)
   cliArgs.ts                     — flag parsing, including --config <path>
 ```

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -78,13 +78,33 @@ Tailwind-class-level sizing or focus-style analysis).
     CSS). `--config` (CLI) / `settings["tailwind-a11y"].configPath` (ESLint) /
     `INPUT_CONFIG` (GitHub Action) exist as explicit overrides, and accept
     either a `.js`/`.cjs` or a `.css` path.
-  - Per color entry (both paths): only a plain hex-string value is accepted
-    (validated with the existing `hexToRgb`) — CSS `oklch()`/`rgb()`/`hsl()`/
-    `var()` etc. are skipped, same "not a hex value -- skip, don't guess"
-    precedent, even though Tailwind v4's own ecosystem leans OKLCH for brand
-    colors. A flat string color (`colors: { brand: '#3490dc' }`) or a
-    `DEFAULT` key is skipped on the JS path — no class syntax
-    (`bg-brand-DEFAULT` isn't real Tailwind) would ever resolve to it.
+  - Per color entry (both paths): a plain hex-string value or a CSS
+    `oklch(L C H)` value is accepted — `themeValueParsers.ts`'s
+    `parseColorScale()` tries `hexToRgb` first, then `oklchToRgb`
+    (`contrast/oklch.ts`), converting an accepted `oklch()` to hex once at
+    ingestion via `rgbToHex` so nothing downstream (`checkContrast.ts`,
+    `checkFocusIndicator.ts`, every adapter) ever needs to know a color
+    started life as OKLCH. Added specifically because Tailwind v4's own
+    default palette and most of its ecosystem (shadcn/ui, v4 starters)
+    define brand colors as `oklch()`, not hex — before this, those colors
+    were silently unresolvable, not "checked and passed." The OKLab
+    conversion matrices were verified against a real headless Chrome
+    (`playwright-core`, canvas + `getImageData` pixel readback — not
+    `getComputedStyle().color`, which modern Chrome now serializes back out
+    as `oklch()` rather than converting to `rgb()`) across in-gamut,
+    out-of-gamut (confirms clamping matches the browser, not just rejection
+    of the in-gamut cases), and percentage-`L`/percentage-`C`/`deg`-suffix
+    syntax variants — 0 channel difference in every case, same "verify
+    against the real tool's actual output, not memory" discipline as the
+    focus-indicator audit below. An alpha component (`oklch(L C H / A)`) or
+    the `none` keyword is unsupported and falls through to skip — the
+    palette only ever stores opaque colors (`HEX_RE` doesn't accept
+    4/8-digit hex with alpha either), so this mirrors an existing limit
+    rather than a new one. `rgb()`/`hsl()`/`var()`/etc. remain skipped, same
+    "not a resolvable value -- skip, don't guess" precedent as before. A
+    flat string color (`colors: { brand: '#3490dc' }`) or a `DEFAULT` key is
+    skipped on the JS path — no class syntax (`bg-brand-DEFAULT` isn't real
+    Tailwind) would ever resolve to it.
   - Per spacing entry (both paths): only `rem`/`px` string values are
     accepted (rem × 16, matching `spacingScale.ts`'s own 16px-root
     assumption).

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,7 +25,7 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                              # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"               # custom glob
 npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
-npx tailwind-a11y --strict                     # touch targets: WCAG 2.5.5 (AAA, 44x44px); focus indicators: also WCAG 2.4.13 (AAA, min thickness)
+npx tailwind-a11y --strict                     # AAA tier: touch targets 2.5.5, focus indicators also 2.4.13, and enables the reduced-motion check (2.3.3)
 npx tailwind-a11y --config ./tw.config.cjs     # use a specific config instead of auto-detecting
 npx tailwind-a11y --version                    # print the installed version
 npx tailwind-a11y --help                       # usage and all options
@@ -57,6 +57,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |
+| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
 
 ## Scope
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -14,6 +14,8 @@ import {
   type FocusContrastViolation,
   type FocusIndicatorViolation,
 } from "./rules/checkFocusIndicator.js";
+import { extractReducedMotionChecks } from "./parser/extractReducedMotion.js";
+import { checkReducedMotion, type ReducedMotionViolation } from "./rules/checkReducedMotion.js";
 import { parseArgs, getHelpText } from "./cliArgs.js";
 import { resolveTheme } from "./theme/loadCustomTheme.js";
 
@@ -21,7 +23,12 @@ import { resolveTheme } from "./theme/loadCustomTheme.js";
 const require = createRequire(import.meta.url);
 const { version: packageVersion } = require("../package.json") as { version: string };
 
-type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 interface Skip {
   file: string;
@@ -48,6 +55,8 @@ function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `${v.line}: <${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 
@@ -115,7 +124,8 @@ async function main(): Promise<void> {
         ...checkContrast(contrastChecks, palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
 
       if (verbose) {

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -14,7 +14,8 @@ export interface ParsedArgs {
 const HELP_TEXT = `Usage: tailwind-a11y [options] [<glob>...]
 
 Static analysis for Tailwind CSS accessibility violations -- color contrast,
-touch target size, and focus indicator removal/contrast.
+touch target size, focus indicator removal/contrast, and reduced-motion
+support for interaction-triggered animation.
 
 Options:
   -v, --verbose      Also report what couldn't be checked, and why
@@ -23,7 +24,10 @@ Options:
       --strict       Touch targets must meet WCAG 2.5.5 (AAA, 44x44px)
                       instead of the default 2.5.8 (AA, 24x24px); focus
                       indicators are also held to 2.4.13 (AAA, minimum
-                      thickness) alongside the default 1.4.11 (AA, contrast)
+                      thickness) alongside the default 1.4.11 (AA, contrast);
+                      also enables the reduced-motion check (WCAG 2.3.3,
+                      AAA-only, off by default -- has no AA tier to fall
+                      back to)
       --config <path>  Path to a tailwind.config.js/.cjs (v3) or a CSS
                         @theme file like app/globals.css (v4) to read
                         custom theme colors/spacing from (default:

--- a/packages/tailwind-a11y/src/contrast/luminance.test.ts
+++ b/packages/tailwind-a11y/src/contrast/luminance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyAlpha, contrastRatio, hexToRgb, meetsWCAG, relativeLuminance, requiredRatio } from "./luminance.js";
+import { applyAlpha, contrastRatio, hexToRgb, meetsWCAG, relativeLuminance, requiredRatio, rgbToHex } from "./luminance.js";
 
 describe("hexToRgb", () => {
   it("parses 6-digit hex with #", () => {
@@ -18,6 +18,22 @@ describe("hexToRgb", () => {
     expect(hexToRgb("not-a-color")).toBeNull();
     expect(hexToRgb("#12345")).toBeNull();
     expect(hexToRgb("")).toBeNull();
+  });
+});
+
+describe("rgbToHex", () => {
+  it("is the exact inverse of hexToRgb for round-trippable values", () => {
+    expect(rgbToHex({ r: 255, g: 255, b: 255 })).toBe("#ffffff");
+    expect(rgbToHex({ r: 0, g: 0, b: 0 })).toBe("#000000");
+    expect(rgbToHex({ r: 0xaa, g: 0xbb, b: 0xcc })).toBe("#aabbcc");
+  });
+
+  it("pads single-digit hex channels with a leading zero", () => {
+    expect(rgbToHex({ r: 5, g: 0, b: 250 })).toBe("#0500fa");
+  });
+
+  it("clamps out-of-range channels rather than producing invalid hex", () => {
+    expect(rgbToHex({ r: 300, g: -10, b: 128 })).toBe("#ff0080");
   });
 });
 

--- a/packages/tailwind-a11y/src/contrast/luminance.ts
+++ b/packages/tailwind-a11y/src/contrast/luminance.ts
@@ -25,6 +25,16 @@ export function hexToRgb(hex: string): RGB | null {
   };
 }
 
+// Inverse of hexToRgb -- used once, by themeValueParsers.ts's
+// parseColorScale(), to turn an accepted oklch() value back into the plain
+// hex string every downstream consumer already expects a palette shade to
+// be. Channels are clamped and rounded rather than assumed already valid,
+// since a caller could in principle pass an out-of-range value.
+export function rgbToHex(rgb: RGB): string {
+  const channel = (c: number) => Math.round(Math.min(255, Math.max(0, c))).toString(16).padStart(2, "0");
+  return `#${channel(rgb.r)}${channel(rgb.g)}${channel(rgb.b)}`;
+}
+
 // Standard "src-over" compositing of a foreground at `alpha` opacity over an
 // opaque background, in gamma-encoded sRGB space (0-255 channels) -- matches
 // how browsers actually composite CSS opacity, no linear-light conversion

--- a/packages/tailwind-a11y/src/contrast/oklch.test.ts
+++ b/packages/tailwind-a11y/src/contrast/oklch.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { oklchToRgb } from "./oklch.js";
+
+// Every expected value here was verified against a real headless Chrome
+// (canvas + getImageData pixel readback, not getComputedStyle) during
+// planning -- these are not hand-computed or estimated.
+describe("oklchToRgb", () => {
+  it.each([
+    ["oklch(1 0 0)", { r: 255, g: 255, b: 255 }],
+    ["oklch(0 0 0)", { r: 0, g: 0, b: 0 }],
+    ["oklch(0.5 0 0)", { r: 99, g: 99, b: 99 }],
+    ["oklch(0.628 0.258 29.23)", { r: 255, g: 0, b: 0 }],
+    ["oklch(0.7 0.15 180)", { r: 0, g: 188, b: 162 }],
+    ["oklch(0.9 0.05 250)", { r: 198, g: 225, b: 255 }],
+    ["oklch(0.4 0.2 300)", { r: 92, g: 17, b: 160 }],
+    // Intentionally out-of-gamut for sRGB -- confirms clamping matches the
+    // browser exactly, not just the in-gamut cases above.
+    ["oklch(0.6 0.3 30)", { r: 255, g: 0, b: 0 }],
+    ["oklch(0.65 0.15 250)", { r: 58, g: 147, b: 230 }],
+  ])("matches the real Chrome-rendered pixel for %s", (input, expected) => {
+    expect(oklchToRgb(input)).toEqual(expected);
+  });
+
+  it("resolves percentage lightness the same as the equivalent 0-1 value", () => {
+    expect(oklchToRgb("oklch(75% 0.1 150)")).toEqual(oklchToRgb("oklch(0.75 0.1 150)"));
+  });
+
+  it("resolves percentage chroma as 100% == 0.4 (the CSS Color 4 reference range)", () => {
+    expect(oklchToRgb("oklch(0.7 50% 180)")).toEqual(oklchToRgb("oklch(0.7 0.2 180)"));
+  });
+
+  it("resolves a deg-suffixed hue the same as a bare degree number", () => {
+    expect(oklchToRgb("oklch(0.7 0.1 180deg)")).toEqual(oklchToRgb("oklch(0.7 0.1 180)"));
+  });
+
+  it("tolerates extra internal whitespace", () => {
+    expect(oklchToRgb("oklch(  0.5   0   0  )")).toEqual(oklchToRgb("oklch(0.5 0 0)"));
+  });
+
+  it.each([
+    "oklch(0.7 0.1 180 / 0.5)", // alpha -- palette only stores opaque colors
+    "oklch(none 0.1 180)", // the `none` keyword
+    "oklch(0.7 none 180)",
+    "rgb(52 144 220)",
+    "var(--some-other-var)",
+    "#3490dc",
+    "not-a-color",
+    "",
+    // Malformed-but-shape-like numbers -- caught in independent review:
+    // Number("0..5") is NaN, and the old [\d.]+ regex accepted this shape,
+    // which would have silently produced {r:NaN,g:NaN,b:NaN} instead of
+    // being rejected outright.
+    "oklch(0..5 0.1 180)",
+    "oklch(0.7 . 180)",
+    "oklch(0.7 0.1 5.)",
+  ])("returns null for unsupported or malformed input: %s", (input) => {
+    expect(oklchToRgb(input)).toBeNull();
+  });
+});

--- a/packages/tailwind-a11y/src/contrast/oklch.ts
+++ b/packages/tailwind-a11y/src/contrast/oklch.ts
@@ -1,0 +1,76 @@
+import type { RGB } from "./luminance.js";
+
+// L and C each accept a plain number or a percentage; H accepts a plain
+// degree number or an explicit `deg` suffix (`180` and `180deg` render
+// identically -- confirmed against a real browser, see below). An alpha
+// component (`/ A`) or the `none` keyword for any channel is deliberately
+// unsupported and falls through to the "not oklch" case below: the palette
+// only ever stores fully opaque colors today (HEX_RE in luminance.ts
+// doesn't accept 4/8-digit hex with alpha either), so this mirrors an
+// existing limit rather than introducing a new one.
+// A real number shape only -- `\d+(?:\.\d+)?|\.\d+` matches "5", "5.5", and
+// ".5" but not "5." or "0..5". The looser `[\d.]+` this replaced accepted
+// "0..5" too, which Number() coerces to NaN -- silently producing an
+// {r:NaN,g:NaN,b:NaN} object where oklchToRgb's contract says this should
+// have been rejected outright (caught in review; the isFinite guard below
+// is a second, independent layer against the same failure mode).
+const NUM = String.raw`\d+(?:\.\d+)?|\.\d+`;
+const OKLCH_RE = new RegExp(`^oklch\\(\\s*(${NUM})(%)?\\s+(${NUM})(%)?\\s+(${NUM})(deg)?\\s*\\)$`);
+
+// Standard OKLab <-> linear sRGB conversion matrices (Björn Ottosson's
+// published reference, the same ones browsers implement per CSS Color 4).
+// Verified this session against a real headless Chrome: rendered each of
+// white/black/a midtone gray/saturated red/teal/purple/an intentionally
+// out-of-gamut saturated red-orange/percentage-L/percentage-C/a deg-suffixed
+// hue onto a <canvas> and read back the actual pixel RGB via getImageData()
+// -- getComputedStyle().color isn't usable for this, since modern Chrome
+// serializes a computed oklch() value back out as oklch(), not rgb(). Every
+// case matched the real browser-rendered pixel exactly (0 channel
+// difference), including the out-of-gamut case, confirming both the
+// matrices and the clamp-before-gamma-encode approach below are correct as
+// implemented, not just approximately close.
+function gammaEncode(linear: number): number {
+  const clamped = Math.min(1, Math.max(0, linear));
+  return clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * clamped ** (1 / 2.4) - 0.055;
+}
+
+export function oklchToRgb(value: string): RGB | null {
+  const match = OKLCH_RE.exec(value.trim());
+  if (!match) return null;
+
+  const [, lRaw, lPct, cRaw, cPct, hRaw] = match;
+  const L = lPct ? Number(lRaw) / 100 : Number(lRaw);
+  const C = cPct ? (Number(cRaw) / 100) * 0.4 : Number(cRaw); // 100% chroma == 0.4, the CSS Color 4 reference range
+  const H = Number(hRaw);
+
+  // Belt-and-suspenders: independent of whether the regex above is airtight,
+  // this makes the RGB | null contract impossible to violate -- a NaN here
+  // would otherwise propagate silently into a "successfully resolved" but
+  // garbage color (rgbToHex would render it as the literal string
+  // "#NaNNaNNaN", which downstream code happens to reject today, but only
+  // by accident of a stricter hex regex elsewhere, not because this
+  // function actually enforced its own contract).
+  if (!Number.isFinite(L) || !Number.isFinite(C) || !Number.isFinite(H)) return null;
+
+  const hRad = (H * Math.PI) / 180;
+  const a = C * Math.cos(hRad);
+  const b = C * Math.sin(hRad);
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+  const l = l_ ** 3;
+  const m = m_ ** 3;
+  const s = s_ ** 3;
+
+  const rLin = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const gLin = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const bLin = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+  return {
+    r: Math.round(gammaEncode(rLin) * 255),
+    g: Math.round(gammaEncode(gLin) * 255),
+    b: Math.round(gammaEncode(bLin) * 255),
+  };
+}

--- a/packages/tailwind-a11y/src/index.ts
+++ b/packages/tailwind-a11y/src/index.ts
@@ -9,6 +9,8 @@ export {
   type FocusIndicatorViolation,
   type FocusContrastViolation,
 } from "./rules/checkFocusIndicator.js";
+export { extractReducedMotionChecks, type ReducedMotionCheck } from "./parser/extractReducedMotion.js";
+export { checkReducedMotion, type ReducedMotionViolation } from "./rules/checkReducedMotion.js";
 export { hexToRgb, contrastRatio, meetsWCAG, requiredRatio, type RGB } from "./contrast/luminance.js";
 export {
   resolveTheme,

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { extractReducedMotionChecks } from "./extractReducedMotion.js";
+
+describe("extractReducedMotionChecks", () => {
+  it("collects an element with a transition base and an interaction-scoped class", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    const checks = extractReducedMotionChecks(code, "fake.tsx");
+    expect(checks).toEqual([
+      {
+        file: "fake.tsx",
+        line: 1,
+        tagName: "div",
+        classes: ["transition-transform", "hover:scale-110"],
+      },
+    ]);
+  });
+
+  it("is not scoped to interactive elements -- a plain div qualifies", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("skips an element with a transition base but no interaction-scoped class", () => {
+    const code = `const C = () => <div className="transition-transform">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("skips an element with an interaction-scoped class but no transition base", () => {
+    const code = `const C = () => <div className="hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("still collects when the only transition base is motion-safe:-scoped (rule decides pass/fail)", () => {
+    const code = `const C = () => <div className="motion-safe:transition-transform hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  // Caught in independent review: variant order shouldn't matter --
+  // motion-safe:hover:scale-110 and hover:motion-safe:scale-110 compile to
+  // the same nested media query (verified against a real Tailwind v4
+  // build), so both must be recognized as interaction-scoped, not just
+  // whichever one happens to put the interaction variant last.
+  it.each(["motion-safe:hover:scale-110", "hover:motion-safe:scale-110"])(
+    "recognizes an interaction variant regardless of its position in a stacked variant, e.g. %s",
+    (stackedClass) => {
+      const code = `const C = () => <div className="transition-transform ${stackedClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+    }
+  );
+
+  it("recognizes focus-within: as an interaction variant", () => {
+    const code = `const C = () => <div className="transition-transform focus-within:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("skips dynamic className without throwing", () => {
+    const code = `const C = ({ x }) => <div className={x ? 'transition-transform hover:scale-110' : ''}>x</div>;`;
+    expect(() => extractReducedMotionChecks(code, "fake.tsx")).not.toThrow();
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+});

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
@@ -1,0 +1,72 @@
+import * as t from "@babel/types";
+import { getStaticClassName, parseJSX, traverse } from "./babelInterop.js";
+
+export interface ReducedMotionCheck {
+  file: string;
+  line: number;
+  tagName: string;
+  // All classes on the element, unfiltered -- checkReducedMotion.ts does
+  // the shape/variant/identity-value classification (unscoped vs
+  // motion-safe:-scoped transition, motion-reduce:-scoped guards,
+  // interaction-scoped transform values), same "extractor collects
+  // broadly, rule filters narrowly" split as extractFocusIndicators.ts/
+  // checkFocusIndicator.ts.
+  classes: string[];
+}
+
+const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
+const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+function baseUtility(raw: string): string {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+
+// Every variant applied to a class, in source order -- NOT just the one
+// immediately before the base utility. Caught in independent review:
+// Tailwind variants stack (`motion-safe:hover:scale-110` and
+// `hover:motion-safe:scale-110` compile to the identical nested media query,
+// confirmed against a real v4 build), so checking only the innermost
+// segment made this extractor's own candidacy gate order-dependent -- it
+// would only recognize the interaction variant when it happened to be
+// written last, silently missing the equally valid `hover:motion-safe:...`
+// ordering. checkReducedMotion.ts uses the same helper for the same reason.
+function variantSegments(raw: string): string[] {
+  return raw.split(":").slice(0, -1);
+}
+
+export function extractReducedMotionChecks(code: string, filePath: string): ReducedMotionCheck[] {
+  const ast = parseJSX(code, filePath);
+  if (!ast) return [];
+
+  const checks: ReducedMotionCheck[] = [];
+
+  traverse(ast, {
+    JSXElement(path) {
+      const opening = path.node.openingElement;
+      const className = getStaticClassName(opening.attributes);
+      if (!className) return;
+
+      const classes = className.split(/\s+/).filter(Boolean);
+
+      const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility(raw)));
+      const hasInteractionClass = classes.some((raw) =>
+        variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v))
+      );
+      // Not a candidate at all unless there's some transition utility
+      // (scoped or not) *and* some interaction-scoped class -- narrows the
+      // set of elements checkReducedMotion.ts has to reason about, without
+      // pre-deciding any of the nuance (unscoped vs motion-safe:, identity
+      // values, motion-reduce: guards) that belongs in the rule.
+      if (!hasTransitionBase || !hasInteractionClass) return;
+
+      checks.push({
+        file: filePath,
+        line: opening.loc?.start.line ?? 0,
+        tagName: t.isJSXIdentifier(opening.name) ? opening.name.name : "unknown-element",
+        classes,
+      });
+    },
+  });
+
+  return checks;
+}

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { checkReducedMotion } from "./checkReducedMotion.js";
+import { extractReducedMotionChecks } from "../parser/extractReducedMotion.js";
+
+function check(classes: string[]) {
+  return { file: "f.tsx", line: 1, tagName: "div", classes };
+}
+
+describe("checkReducedMotion", () => {
+  it("reports nothing by default (strict not passed) even for an otherwise-real violation", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])]);
+    expect(violations).toEqual([]);
+  });
+
+  it("reports nothing when strict is explicitly false", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])], false);
+    expect(violations).toEqual([]);
+  });
+
+  it("flags an unscoped transition-transform with an interaction-scoped scale and no guard, under strict", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([
+      {
+        type: "reduced-motion",
+        file: "f.tsx",
+        line: 1,
+        tagName: "div",
+        transitionClass: "transition-transform",
+        motionClass: "hover:scale-110",
+        level: "AAA",
+      },
+    ]);
+  });
+
+  it("passes when a motion-reduce:transition-none guard is present", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-reduce:transition-none"])],
+      true
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("passes when a motion-reduce:transform-none guard is present", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-reduce:transform-none"])],
+      true
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("passes when the transition is scoped under motion-safe: instead of unscoped (complete alternative)", () => {
+    const violations = checkReducedMotion([check(["motion-safe:transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  // Caught in independent review: motion-safe:hover:scale-110 and
+  // hover:motion-safe:scale-110 compile to the identical nested media query
+  // (confirmed against a real Tailwind v4 build) -- both must be treated as
+  // "this motion utility only applies when motion is already safe,"
+  // regardless of which variant was written first.
+  it.each(["motion-safe:hover:scale-110", "hover:motion-safe:scale-110"])(
+    "passes when the interaction-scoped motion utility is itself motion-safe:-guarded, in either variant order: %s",
+    (motionClass) => {
+      const violations = checkReducedMotion([check(["transition-transform", motionClass])], true);
+      expect(violations).toEqual([]);
+    }
+  );
+
+  it("still flags a plain hover:scale-110 (no motion-safe: anywhere) alongside an unrelated motion-safe:-guarded class", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-safe:hover:rotate-3"])],
+      true
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].motionClass).toBe("hover:scale-110");
+  });
+
+  it("recognizes focus-within: as an interaction variant", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "focus-within:scale-110"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("does not flag transition-colors -- it doesn't animate transform/scale/rotate/translate", () => {
+    const violations = checkReducedMotion([check(["transition-colors", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("bare transition (the default property list) still counts -- it includes transform/scale/rotate/translate", () => {
+    const violations = checkReducedMotion([check(["transition", "hover:scale-110"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("transition-all still counts", () => {
+    const violations = checkReducedMotion([check(["transition-all", "hover:rotate-45"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it.each(["hover:scale-100", "focus:rotate-0", "active:translate-x-0", "hover:-translate-y-0", "focus-visible:skew-x-0"])(
+    "does not flag an identity-value interaction utility: %s",
+    (identity) => {
+      const violations = checkReducedMotion([check(["transition-transform", identity])], true);
+      expect(violations).toEqual([]);
+    }
+  );
+
+  it.each(["hover:scale-110", "hover:scale-x-125", "focus:rotate-3", "active:-rotate-6", "hover:-translate-y-1", "focus-visible:skew-x-6"])(
+    "flags a real, non-identity interaction motion utility: %s",
+    (motion) => {
+      const violations = checkReducedMotion([check(["transition-transform", motion])], true);
+      expect(violations).toHaveLength(1);
+    }
+  );
+
+  it("does not flag when there's a transition but no interaction-scoped motion utility at all", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:bg-blue-500"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("does not flag when the transition itself is hover-scoped (not present in the resting state)", () => {
+    const violations = checkReducedMotion([check(["hover:transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("composes end-to-end with extractReducedMotionChecks", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    const violations = checkReducedMotion(extractReducedMotionChecks(code, "fake.tsx"), true);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].type).toBe("reduced-motion");
+  });
+});

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
@@ -1,0 +1,124 @@
+import type { ReducedMotionCheck } from "../parser/extractReducedMotion.js";
+
+export interface ReducedMotionViolation {
+  type: "reduced-motion";
+  file: string;
+  line: number;
+  tagName: string;
+  transitionClass: string;
+  motionClass: string;
+  level: "AAA"; // no AA tier exists for this SC to fall back to
+}
+
+// Verified against a real Tailwind v4 build: only these three include
+// transform/translate/scale/rotate in their transition-property list.
+// transition-colors/-opacity/-shadow don't -- so a scale/rotate/translate
+// change under hover on an element with only one of those never actually
+// animates (the browser has nothing telling it to transition that
+// property), and correctly isn't flagged.
+const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
+const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+function baseUtility(raw: string): string {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+
+// Every variant applied to a class, in source order -- see the identical
+// helper (and full explanation) in extractReducedMotion.ts. Duplicated
+// rather than imported, matching this codebase's own established
+// precedent of small per-file primitives (e.g. checkFocusIndicator.ts's own
+// baseUtility is separate from extractFocusIndicators.ts's).
+function variantSegments(raw: string): string[] {
+  return raw.split(":").slice(0, -1);
+}
+
+// Positive shape filter, not a denylist -- same reasoning as COLOR_TOKEN in
+// extractClasses.ts. Excludes each utility's identity value (scale-100,
+// rotate-0, translate-x-0/-y-0, skew-x-0/-y-0), since those utilities are
+// real but move nothing -- flagging them would be a false positive, the
+// same "shape looks real but isn't" failure class this project has hit
+// before. Arbitrary bracket values (scale-[1.5]) and 3D transform utilities
+// (rotate-x-*, translate-z-*, ...) are out of scope for v1 -- unmatched, so
+// silently not considered "motion" here rather than guessed at.
+const SCALE_RE = /^(scale|scale-x|scale-y)-(\d+)$/;
+const ROTATE_RE = /^-?rotate-(\d+(?:\.\d+)?)$/;
+const TRANSLATE_RE = /^-?(translate-x|translate-y)-(\d+(?:\.\d+)?)$/;
+const SKEW_RE = /^-?(skew-x|skew-y)-(\d+(?:\.\d+)?)$/;
+
+function isNonIdentityMotionUtility(base: string): boolean {
+  const scale = SCALE_RE.exec(base);
+  if (scale) return Number(scale[2]) !== 100;
+  const rotate = ROTATE_RE.exec(base);
+  if (rotate) return Number(rotate[1]) !== 0;
+  const translate = TRANSLATE_RE.exec(base);
+  if (translate) return Number(translate[2]) !== 0;
+  const skew = SKEW_RE.exec(base);
+  if (skew) return Number(skew[2]) !== 0;
+  return false;
+}
+
+// `strict` gates the whole check for the scan-everything-by-default
+// adapters (CLI/VS Code/GitHub Action) -- WCAG 2.3.3 is AAA-only, and
+// unconditionally enabling a brand-new AAA check would silently start
+// failing existing users' CI on a routine upgrade, unlike a genuine AA
+// baseline (2.4.7's focus-indicator check, the one other check in this file
+// with no strict tier). Consistent with this project's own `strict` =
+// "hold every check to its AAA tier where one exists" framing. The ESLint
+// rule is the one caller that always passes `true` regardless -- enabling
+// `tailwind-a11y/reduced-motion` in an ESLint config is itself the opt-in
+// gesture there, so a second gate on top would just make the rule silently
+// report nothing when a user enabled it expecting it to check something.
+export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false): ReducedMotionViolation[] {
+  if (!strict) return [];
+
+  const violations: ReducedMotionViolation[] = [];
+
+  for (const check of checks) {
+    let unscopedTransition: string | null = null;
+    let hasMotionReduceGuard = false;
+
+    for (const raw of check.classes) {
+      const base = baseUtility(raw);
+      const segments = variantSegments(raw);
+
+      if (segments.length === 0 && TRANSITION_BASES.has(base)) unscopedTransition = raw;
+
+      if (segments.includes("motion-reduce") && (base === "transition-none" || base === "transform-none")) {
+        hasMotionReduceGuard = true;
+      }
+    }
+
+    // A transition scoped only under motion-safe: (never unscoped) means it
+    // simply doesn't exist unless motion is already safe -- a complete
+    // alternative way of satisfying 2.3.3, not a partial one -- so this
+    // correctly falls through as a pass, not a skip-because-unresolvable.
+    if (!unscopedTransition) continue;
+    if (hasMotionReduceGuard) continue;
+
+    const motionClass = check.classes.find((raw) => {
+      const segments = variantSegments(raw);
+      // motion-safe: anywhere in this specific class's own variant stack
+      // means the motion utility itself doesn't apply unless motion is
+      // already safe -- the same complete-alternative reasoning as the
+      // transition side above, just checked per-candidate instead of once
+      // for the whole element (a class can be interaction-scoped *and*
+      // self-guarded at the same time, e.g. `hover:motion-safe:scale-110`).
+      if (segments.includes("motion-safe")) return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS.has(v))) return false;
+      return isNonIdentityMotionUtility(baseUtility(raw));
+    });
+    if (!motionClass) continue; // no real, un-self-guarded motion actually triggered by interaction
+
+    violations.push({
+      type: "reduced-motion",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      transitionClass: unscopedTransition,
+      motionClass,
+      level: "AAA",
+    });
+  }
+
+  return violations;
+}

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
@@ -155,6 +155,15 @@ describe("loadCustomTheme", () => {
     expect(loadCustomTheme(configPath)).toEqual({});
   });
 
+  it("resolves an oklch() color value to its hex equivalent", () => {
+    const configPath = join(dir, "tailwind.config.js");
+    writeFileSync(
+      configPath,
+      `module.exports = { theme: { extend: { colors: { brand: { 500: "oklch(0.7 0.15 180)" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#00bca2" } } });
+  });
+
   it("skips a non-rem/px spacing value", () => {
     const configPath = join(dir, "tailwind.config.js");
     writeFileSync(configPath, `module.exports = { theme: { extend: { spacing: { "18": "50%" } } } };`);

--- a/packages/tailwind-a11y/src/theme/parseThemeCss.test.ts
+++ b/packages/tailwind-a11y/src/theme/parseThemeCss.test.ts
@@ -85,8 +85,8 @@ describe("parseThemeCss", () => {
     });
   });
 
-  it.each(["oklch(0.6 0.2 250)", "rgb(52 144 220)", "var(--some-other-var)"])(
-    "skips a non-hex color value %s",
+  it.each(["rgb(52 144 220)", "var(--some-other-var)"])(
+    "skips a non-hex, non-oklch color value %s",
     (value) => {
       const css = `
         @theme {
@@ -96,6 +96,17 @@ describe("parseThemeCss", () => {
       expect(parseThemeCss(css)).toEqual({});
     }
   );
+
+  it("resolves an oklch() color value (Tailwind v4's own default palette uses this)", () => {
+    const css = `
+      @theme {
+        --color-brand-500: oklch(0.7 0.15 180);
+      }
+    `;
+    expect(parseThemeCss(css)).toEqual({
+      colors: { brand: { "500": "#00bca2" } },
+    });
+  });
 
   it("skips a non-rem/px spacing value", () => {
     const css = `

--- a/packages/tailwind-a11y/src/theme/themeValueParsers.ts
+++ b/packages/tailwind-a11y/src/theme/themeValueParsers.ts
@@ -1,4 +1,5 @@
-import { hexToRgb } from "../contrast/luminance.js";
+import { hexToRgb, rgbToHex } from "../contrast/luminance.js";
+import { oklchToRgb } from "../contrast/oklch.js";
 
 const SPACING_RE = /^-?[\d.]+(rem|px)$/;
 
@@ -14,14 +15,28 @@ export function parseSpacingValue(value: unknown): number | null {
 // A flat string color (`brand: '#3490dc'`) or a `DEFAULT` key is skipped
 // entirely -- there's no class syntax ("bg-brand-DEFAULT" isn't real Tailwind)
 // that would ever resolve to it, so partially supporting it would be dead code.
+// Resolves a shade value to the plain hex string every downstream consumer
+// (resolveColorValue -> hexToRgb in checkContrast.ts/checkFocusIndicator.ts)
+// already assumes every palette entry is. A hex value is stored as-is; an
+// oklch() value is converted to hex once, here, so the conversion never has
+// to be repeated (or reimplemented) at every place a palette color gets
+// used. Anything else (rgb()/hsl()/var()/lab()/lch()/color()/...) is still
+// skipped -- out of scope for now, same "don't guess" precedent as before.
+function resolveShadeHex(shadeValue: string): string | null {
+  if (hexToRgb(shadeValue) !== null) return shadeValue;
+  const oklchRgb = oklchToRgb(shadeValue);
+  return oklchRgb ? rgbToHex(oklchRgb) : null;
+}
+
 export function parseColorScale(value: unknown): Record<string, string> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   const shades: Record<string, string> = {};
   for (const [shade, shadeValue] of Object.entries(value)) {
     if (shade === "DEFAULT") continue; // no "bg-brand-DEFAULT" class syntax exists to resolve it
     if (typeof shadeValue !== "string") continue;
-    if (hexToRgb(shadeValue) === null) continue; // not a hex value -- skip, don't guess
-    shades[shade] = shadeValue;
+    const hex = resolveShadeHex(shadeValue);
+    if (hex === null) continue; // neither hex nor oklch -- skip, don't guess
+    shades[shade] = hex;
   }
   return Object.keys(shades).length > 0 ? shades : null;
 }

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -15,6 +15,7 @@ reimplemented here.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |
+| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
 (debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
@@ -32,9 +33,11 @@ setting:
 ```
 
 Set `tailwind-a11y.strict` to enforce the stricter 44×44px touch target
-minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA), and to
+minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA), to
 also require focus indicators to meet WCAG 2.4.13's minimum thickness
-alongside the always-on 3:1 contrast check (1.4.11):
+alongside the always-on 3:1 contrast check (1.4.11), and to enable the
+reduced-motion check (WCAG 2.3.3, AAA-only, off unless `strict` is set —
+there's no AA tier for it to fall back to):
 
 ```json
 { "tailwind-a11y.strict": true }

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -41,7 +41,7 @@
           "type": "boolean",
           "default": false,
           "scope": "resource",
-          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check."
+          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check, and the reduced-motion check (WCAG 2.3.3, AAA-only, off by default -- has no AA tier to fall back to)."
         }
       }
     }
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.11.0"
+    "tailwind-a11y": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.10.0"
+    "tailwind-a11y": "^0.11.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -7,6 +7,8 @@ import {
   extractFocusIndicatorChecks,
   checkFocusIndicators,
   checkFocusContrast,
+  extractReducedMotionChecks,
+  checkReducedMotion,
   resolveTheme,
 } from "tailwind-a11y";
 import { formatViolation, type AnyViolation } from "./format.js";
@@ -96,6 +98,7 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
     ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing), strict),
     ...checkFocusIndicators(focusChecks),
     ...checkFocusContrast(focusChecks, strict, palette),
+    ...checkReducedMotion(extractReducedMotionChecks(text, file), strict),
   ];
 
   return violations.map((v) => {

--- a/packages/vscode-tailwind-a11y/src/format.test.ts
+++ b/packages/vscode-tailwind-a11y/src/format.test.ts
@@ -110,4 +110,19 @@ describe("formatViolation", () => {
       "<button> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
     );
   });
+
+  it("formats a reduced-motion violation", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      file: "f.tsx",
+      line: 1,
+      tagName: "div",
+      transitionClass: "transition-transform",
+      motionClass: "hover:scale-110",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
 });

--- a/packages/vscode-tailwind-a11y/src/format.ts
+++ b/packages/vscode-tailwind-a11y/src/format.ts
@@ -1,6 +1,17 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
+import type {
+  ContrastViolation,
+  TouchTargetViolation,
+  FocusIndicatorViolation,
+  FocusContrastViolation,
+  ReducedMotionViolation,
+} from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+export type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 // Mirrors cli.ts's formatViolation, minus the leading "${line}: " prefix —
 // VS Code renders the diagnostic's location itself. Kept in its own module
@@ -25,5 +36,7 @@ export function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }


### PR DESCRIPTION
## What

Custom theme colors (`theme.extend.colors` in a v3 config, `--color-*` in a v4 `@theme` block) only ever accepted a plain hex string per shade. Anything else, including `oklch()`, was silently skipped -- not "checked and passed," just never evaluated. That's a real gap: Tailwind v4's own default palette, and most of its ecosystem (shadcn/ui, v4 starters), defines brand colors as `oklch(L C H)`, not hex. A v4 project using an OKLCH brand color got zero contrast or focus-contrast checking against it.

`parseColorScale()` now tries hex first as before, then falls back to a new `oklchToRgb()`, converting an accepted value to hex once at ingestion. Nothing downstream changes -- `checkContrast.ts`, `checkFocusIndicator.ts`, and all four adapters keep assuming every palette entry is plain hex, because by the time they see it, it is. Both the v3 and v4 config loaders already funnel every color through this same function, so this one change covers both formats at once. `rgb()`, `hsl()`, `var()`, and everything else stay out of scope, skipped exactly as before.

## Verification

The OKLab-to-sRGB conversion matrices aren't something to eyeball -- got them wrong and every contrast ratio for an OKLCH-themed project would be silently off. Installed `playwright-core`, launched real headless Chrome, and rendered a dozen test colors (white, black, saturated hues, an intentionally out-of-gamut case, percentage lightness, percentage chroma, a `deg`-suffixed hue) onto a canvas, reading back the actual pixel RGB via `getImageData` -- `getComputedStyle().color` doesn't work for this anymore, since modern Chrome serializes a computed `oklch()` value back out as `oklch()`, not `rgb()`. Every case matched exactly, 0 channel difference, including the out-of-gamut one.

Independent review caught a real bug before this shipped: the number-matching regex accepted malformed shapes like `"0..5"`, which `Number()` turns into `NaN`, so a bad value would have silently resolved to `{r: NaN, g: NaN, b: NaN}` instead of being rejected. Fixed with a stricter number pattern and an explicit `Number.isFinite` check as a second, independent guard, plus regression tests for the exact malformed inputs.

## Versions

Engine, eslint-plugin, and the GitHub Action go 0.10.0 -> 0.11.0. VS Code goes 0.11.0 -> 0.12.0, matching its usual one-ahead offset.

## Test plan

- [x] Full test suite passes across all four packages (356 tests)
- [x] Real-Chrome pixel verification against the actual compiled output, not just the source
- [x] End-to-end CLI run against a scratch v4 `@theme` fixture and a scratch v3 config, both with an OKLCH brand color used in both the contrast and focus-contrast checks -- both fire correctly; a high-contrast OKLCH pair produces zero false positives
- [x] GitHub Action bundle rebuilt and confirmed non-stale
- [x] Independent review pass, with a real bug found, fixed, and re-verified