### PR TITLE
Add reduced-motion check: WCAG 2.3.3 (AAA-only, strict-gated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.11.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.12.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ they ship, instead of at a Lighthouse audit or QA pass.
 | [`vscode-tailwind-a11y`](./packages/vscode-tailwind-a11y) | Live editor diagnostics |
 | [`github-action-tailwind-a11y`](./packages/github-action-tailwind-a11y) | Inline PR annotations (`uses: chamroro/tailwind-a11y@v0`) |
 
-All four run the same four checks — color contrast (WCAG 1.4.3), touch target size
-(WCAG 2.5.8, or 2.5.5 in strict mode), focus indicator removal (WCAG 2.4.7), and focus
-indicator contrast (WCAG 1.4.11, or also 2.4.13 in strict mode) — through one shared
-engine, so results never disagree between them. See each package's README for install
-and usage.
+All four run the same five checks — color contrast (WCAG 1.4.3), touch target size
+(WCAG 2.5.8, or 2.5.5 in strict mode), focus indicator removal (WCAG 2.4.7), focus
+indicator contrast (WCAG 1.4.11, or also 2.4.13 in strict mode), and reduced motion for
+interaction-triggered animation (WCAG 2.3.3, strict-mode only — no AA tier exists) —
+through one shared engine, so results never disagree between them. See each package's
+README for install and usage.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,9 @@ inputs:
   strict:
     description: >-
       Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default
-      2.5.8 (AA, 24x24px).
+      2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness
+      alongside the always-on 1.4.11 (AA) contrast check, and the
+      reduced-motion check (WCAG 2.3.3, AAA-only, off by default).
     required: false
     default: "false"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.11.0"
+        "tailwind-a11y": "^0.12.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -46,6 +46,7 @@ export default [
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |
+| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 
@@ -84,6 +85,26 @@ export default [
   },
 ];
 ```
+
+## Reduced motion (AAA-only, opt-in)
+
+`reduced-motion` has no AA tier to fall back to, so it isn't part of
+`configs.recommended` the way the other three rules are — enable it
+explicitly if you want it:
+
+```js
+export default [
+  ...tailwindA11y.configs.recommended,
+  {
+    files: ["**/*.jsx", "**/*.tsx"],
+    plugins: { "tailwind-a11y": tailwindA11y },
+    rules: { "tailwind-a11y/reduced-motion": "warn" },
+  },
+];
+```
+
+No `strict` option here (unlike `touch-target`/`focus-contrast`) — enabling
+the rule at all is already the opt-in gesture.
 
 ## Notes
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.11.0"
+    "tailwind-a11y": "^0.12.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/index.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/index.ts
@@ -4,6 +4,7 @@ import contrast from "./rules/contrast.js";
 import touchTarget from "./rules/touch-target.js";
 import focusIndicator from "./rules/focus-indicator.js";
 import focusContrast from "./rules/focus-contrast.js";
+import reducedMotion from "./rules/reduced-motion.js";
 
 // `../package.json` resolves correctly from both `src/` (dev) and `dist/`
 // (published), so the plugin version can't drift from the package version.
@@ -21,6 +22,7 @@ const plugin: ESLint.Plugin = {
     "touch-target": touchTarget,
     "focus-indicator": focusIndicator,
     "focus-contrast": focusContrast,
+    "reduced-motion": reducedMotion,
   },
   configs: {},
 };
@@ -40,6 +42,12 @@ Object.assign(plugin.configs!, {
       // README for the TS-parser caveat.
       languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
       plugins: { "tailwind-a11y": plugin },
+      // reduced-motion is deliberately not included here: every other rule
+      // has an AA baseline `recommended` can reasonably assume most
+      // projects want, but WCAG 2.3.3 (what reduced-motion enforces) is
+      // AAA-only with no AA fallback -- silently bundling an AAA-only rule
+      // into "recommended" would surprise users who added this plugin
+      // expecting an AA floor. See README for enabling it explicitly.
       rules: {
         "tailwind-a11y/contrast": "error",
         "tailwind-a11y/touch-target": "error",

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+import rule from "./reduced-motion.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run("reduced-motion", rule, {
+  valid: [
+    {
+      name: "a motion-reduce:transform-none guard passes",
+      filename: "Ok.jsx",
+      code: `export const Ok = () => <div className="transition-transform hover:scale-110 motion-reduce:transform-none">x</div>;`,
+    },
+    {
+      name: "a transition scoped under motion-safe: instead of unscoped passes",
+      filename: "Ok2.jsx",
+      code: `export const Ok = () => <div className="motion-safe:transition-transform hover:scale-110">x</div>;`,
+    },
+    {
+      name: "transition-colors doesn't animate transform, so no violation",
+      filename: "Colors.jsx",
+      code: `export const D = () => <div className="transition-colors hover:scale-110">x</div>;`,
+    },
+    {
+      name: "an identity-value interaction utility (scale-100) is not real motion",
+      filename: "Identity.jsx",
+      code: `export const D = () => <div className="transition-transform hover:scale-100">x</div>;`,
+    },
+  ],
+  invalid: [
+    {
+      name: "an unscoped transition-transform with an interaction-scoped scale and no guard is enabling this rule's opt-in, so it fires without a strict option",
+      filename: "Card.jsx",
+      code: `export const Card = () => <div className="transition-transform hover:scale-110">x</div>;`,
+      errors: [
+        {
+          message:
+            "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+  ],
+  assertionOptions: { requireLocation: true, requireMessage: true },
+});

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
@@ -1,0 +1,49 @@
+import type { Rule } from "eslint";
+import { extractReducedMotionChecks, checkReducedMotion } from "tailwind-a11y";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce WCAG 2.3.3 AAA -- interaction-triggered transform animation (scale/rotate/translate/skew under hover:/focus:/active:) must be disableable via prefers-reduced-motion",
+      recommended: true,
+      url: "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#reduced-motion",
+    },
+    // No AA tier to fall back to for this SC, unlike touch-target/
+    // focus-contrast -- no strict option, same schema: [] as the original
+    // focus-indicator rule. checkReducedMotion() itself defaults to
+    // reporting nothing unless told `strict` (the CLI/VS Code/GitHub Action
+    // gate this behind --strict/tailwind-a11y.strict/INPUT_STRICT, since
+    // those tools scan everything by default and an AAA-only check
+    // shouldn't silently start failing existing users' CI on upgrade) --
+    // here, enabling this rule at all is already that opt-in gesture, so
+    // this is the one caller that always passes `true`.
+    schema: [],
+    messages: {
+      reducedMotion:
+        "<{{tagName}}> animates {{motionClass}} via {{transitionClass}} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+    },
+  },
+
+  create(context) {
+    return {
+      Program() {
+        const violations = checkReducedMotion(
+          extractReducedMotionChecks(context.sourceCode.getText(), context.filename),
+          true
+        );
+
+        for (const v of violations) {
+          context.report({
+            loc: { line: v.line, column: 0 },
+            messageId: "reducedMotion",
+            data: { tagName: v.tagName, motionClass: v.motionClass, transitionClass: v.transitionClass },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -30,7 +30,7 @@ found (configurable below).
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
 | `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
-| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check |
+| `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check, and the reduced-motion check (WCAG 2.3.3, AAA-only, off by default) |
 
 ```yaml
 - uses: chamroro/tailwind-a11y@v0

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -2647,8 +2647,8 @@ var require_parse2 = __commonJS({
             brace.value = brace.output = "\\{";
             value = output = "\\}";
             state.output = out;
-            for (const t6 of toks) {
-              state.output += t6.output || t6.value;
+            for (const t7 of toks) {
+              state.output += t7.output || t7.value;
             }
           }
           push({ type: "brace", value, output });
@@ -5974,7 +5974,7 @@ var require_generated = __commonJS({
     exports2.isJSXEmptyExpression = isJSXEmptyExpression;
     exports2.isJSXExpressionContainer = isJSXExpressionContainer;
     exports2.isJSXFragment = isJSXFragment2;
-    exports2.isJSXIdentifier = isJSXIdentifier5;
+    exports2.isJSXIdentifier = isJSXIdentifier6;
     exports2.isJSXMemberExpression = isJSXMemberExpression;
     exports2.isJSXNamespacedName = isJSXNamespacedName;
     exports2.isJSXOpeningElement = isJSXOpeningElement;
@@ -6959,7 +6959,7 @@ var require_generated = __commonJS({
       if (node.type !== "JSXSpreadChild") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
     }
-    function isJSXIdentifier5(node, opts) {
+    function isJSXIdentifier6(node, opts) {
       if (!node) return false;
       if (node.type !== "JSXIdentifier") return false;
       return opts == null || (0, _shallowEqual.default)(node, opts);
@@ -19848,12 +19848,12 @@ var require_lib4 = __commonJS({
     });
     function _objectWithoutPropertiesLoose(r, e) {
       if (null == r) return {};
-      var t6 = {};
+      var t7 = {};
       for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
         if (-1 !== e.indexOf(n)) continue;
-        t6[n] = r[n];
+        t7[n] = r[n];
       }
-      return t6;
+      return t7;
     }
     var Position = class {
       constructor(line, col, index) {
@@ -28456,7 +28456,7 @@ var require_lib4 = __commonJS({
       }
       tsParseTypeOrTypePredicateAnnotation(returnToken) {
         return this.tsInType(() => {
-          const t6 = this.startNode();
+          const t7 = this.startNode();
           this.expect(returnToken);
           const node = this.startNode();
           const asserts = !!this.tsTryParse(this.tsParseTypePredicateAsserts.bind(this));
@@ -28471,26 +28471,26 @@ var require_lib4 = __commonJS({
               this.resetStartLocationFromNode(thisTypePredicate, node);
               thisTypePredicate.asserts = true;
             }
-            t6.typeAnnotation = thisTypePredicate;
-            return this.finishNode(t6, "TSTypeAnnotation");
+            t7.typeAnnotation = thisTypePredicate;
+            return this.finishNode(t7, "TSTypeAnnotation");
           }
           const typePredicateVariable = this.tsIsIdentifier() && this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
           if (!typePredicateVariable) {
             if (!asserts) {
-              return this.tsParseTypeAnnotation(false, t6);
+              return this.tsParseTypeAnnotation(false, t7);
             }
             node.parameterName = this.parseIdentifier();
             node.asserts = asserts;
             node.typeAnnotation = null;
-            t6.typeAnnotation = this.finishNode(node, "TSTypePredicate");
-            return this.finishNode(t6, "TSTypeAnnotation");
+            t7.typeAnnotation = this.finishNode(node, "TSTypePredicate");
+            return this.finishNode(t7, "TSTypeAnnotation");
           }
           const type = this.tsParseTypeAnnotation(false);
           node.parameterName = typePredicateVariable;
           node.typeAnnotation = type;
           node.asserts = asserts;
-          t6.typeAnnotation = this.finishNode(node, "TSTypePredicate");
-          return this.finishNode(t6, "TSTypeAnnotation");
+          t7.typeAnnotation = this.finishNode(node, "TSTypePredicate");
+          return this.finishNode(t7, "TSTypeAnnotation");
         });
       }
       tsTryParseTypeOrTypePredicateAnnotation() {
@@ -28529,12 +28529,12 @@ var require_lib4 = __commonJS({
         }
         return true;
       }
-      tsParseTypeAnnotation(eatColon = true, t6 = this.startNode()) {
+      tsParseTypeAnnotation(eatColon = true, t7 = this.startNode()) {
         this.tsInType(() => {
           if (eatColon) this.expect(14);
-          t6.typeAnnotation = this.tsParseType();
+          t7.typeAnnotation = this.tsParseType();
         });
-        return this.finishNode(t6, "TSTypeAnnotation");
+        return this.finishNode(t7, "TSTypeAnnotation");
       }
       tsParseType() {
         assert(this.state.inType);
@@ -30515,7 +30515,7 @@ var require_lib4 = __commonJS({
           }
           const topicToken = pluginsMap.get("pipelineOperator").topicToken;
           if (!TOPIC_TOKENS.includes(topicToken)) {
-            const tokenList = TOPIC_TOKENS.map((t6) => `"${t6}"`).join(", ");
+            const tokenList = TOPIC_TOKENS.map((t7) => `"${t7}"`).join(", ");
             throw new Error(`"pipelineOperator" in "proposal": "hack" mode also requires a "topicToken" option whose value must be one of: ${tokenList}.`);
           }
           if (topicToken === "#" && ((_pluginsMap$get = pluginsMap.get("recordAndTuple")) == null ? void 0 : _pluginsMap$get.syntaxType) === "hash") {
@@ -35241,7 +35241,7 @@ var require_virtual_types_validator = __commonJS({
       isIdentifier,
       isImportDeclaration,
       isImportSpecifier,
-      isJSXIdentifier: isJSXIdentifier5,
+      isJSXIdentifier: isJSXIdentifier6,
       isJSXMemberExpression,
       isMemberExpression,
       isRestElement: nodeIsRestElement,
@@ -35263,7 +35263,7 @@ var require_virtual_types_validator = __commonJS({
       } = this;
       if (isIdentifier(node, opts)) {
         return nodeIsReferenced(node, parent, this.parentPath.parent);
-      } else if (isJSXIdentifier5(node, opts)) {
+      } else if (isJSXIdentifier6(node, opts)) {
         if (!isJSXMemberExpression(parent) && isCompatTag(node.name)) return false;
         return nodeIsReferenced(node, parent, this.parentPath.parent);
       } else {
@@ -35634,8 +35634,8 @@ var require_renamer = __commonJS({
       value: true
     });
     exports2.default = void 0;
-    var t6 = require_lib3();
-    var _t = t6;
+    var t7 = require_lib3();
+    var _t = t7;
     var _traverseNode = require_traverse_node();
     var _visitors = require_visitors();
     var _context = require_context2();
@@ -35701,7 +35701,7 @@ var require_renamer = __commonJS({
           const {
             declaration
           } = maybeExportDeclar.node;
-          if (t6.isDeclaration(declaration) && !declaration.id) {
+          if (t7.isDeclaration(declaration) && !declaration.id) {
             return;
           }
         }
@@ -35737,11 +35737,11 @@ var require_renamer = __commonJS({
         const skipKeys = {
           discriminant: true
         };
-        if (t6.isMethod(blockToTraverse)) {
+        if (t7.isMethod(blockToTraverse)) {
           if (blockToTraverse.computed) {
             skipKeys.key = true;
           }
-          if (!t6.isObjectMethod(blockToTraverse)) {
+          if (!t7.isObjectMethod(blockToTraverse)) {
             skipKeys.decorators = true;
           }
         }
@@ -36048,7 +36048,7 @@ var require_scope = __commonJS({
     var _traverseForScope = require_traverseForScope();
     var _binding = require_binding();
     var _t = require_lib3();
-    var t6 = _t;
+    var t7 = _t;
     var _cache = require_cache();
     var globalsBuiltinLower = require_builtin_lower();
     var globalsBuiltinUpper = require_builtin_upper();
@@ -36253,7 +36253,7 @@ var require_scope = __commonJS({
         parent.registerDeclaration(path);
       },
       ReferencedIdentifier(path, state) {
-        if (t6.isTSQualifiedName(path.parent) && path.parent.right === path.node) {
+        if (t7.isTSQualifiedName(path.parent) && path.parent.right === path.node) {
           return;
         }
         if (path.parentPath.isTSImportEqualsDeclaration()) return;
@@ -36673,7 +36673,7 @@ var require_scope = __commonJS({
         } else if (isCallExpression(node)) {
           return matchesPattern(node.callee, "Symbol.for") && !this.hasBinding("Symbol", {
             noGlobals: true
-          }) && node.arguments.length === 1 && t6.isStringLiteral(node.arguments[0]);
+          }) && node.arguments.length === 1 && t7.isStringLiteral(node.arguments[0]);
         } else {
           return isPureish(node);
         }
@@ -40179,7 +40179,7 @@ var require_typescript2 = __commonJS({
       this.tokenChar(60);
       let printTrailingSeparator = parent.type === "ArrowFunctionExpression" && node.params.length === 1;
       if (this.tokenMap && node.start != null && node.end != null) {
-        printTrailingSeparator && (printTrailingSeparator = !!this.tokenMap.find(node, (t6) => this.tokenMap.matchesOriginal(t6, ",")));
+        printTrailingSeparator && (printTrailingSeparator = !!this.tokenMap.find(node, (t7) => this.tokenMap.matchesOriginal(t7, ",")));
         printTrailingSeparator || (printTrailingSeparator = this.shouldPrintTrailingComma(">"));
       }
       this.printList(node.params, printTrailingSeparator);
@@ -45141,7 +45141,7 @@ var require_removal = __commonJS({
     var _cache = require_cache();
     var _replacement = require_replacement();
     var _index = require_path2();
-    var t6 = require_lib3();
+    var t7 = require_lib3();
     var _modification = require_modification();
     var _context = require_context2();
     function remove() {
@@ -45160,7 +45160,7 @@ var require_removal = __commonJS({
       _markRemoved.call(this);
     }
     function _removeFromScope() {
-      const bindings = t6.getBindingIdentifiers(this.node, false, false, true);
+      const bindings = t7.getBindingIdentifiers(this.node, false, false, true);
       Object.keys(bindings).forEach((name) => this.scope.removeBinding(name));
     }
     function _callRemovalHooks() {
@@ -46326,12 +46326,12 @@ var require_options = __commonJS({
     var _excluded = ["placeholderWhitelist", "placeholderPattern", "preserveComments", "syntacticPlaceholders"];
     function _objectWithoutPropertiesLoose(r, e) {
       if (null == r) return {};
-      var t6 = {};
+      var t7 = {};
       for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
         if (-1 !== e.indexOf(n)) continue;
-        t6[n] = r[n];
+        t7[n] = r[n];
       }
-      return t6;
+      return t7;
     }
     function merge(a, b) {
       const {
@@ -46411,7 +46411,7 @@ var require_parse3 = __commonJS({
       isExpressionStatement,
       isFunction,
       isIdentifier,
-      isJSXIdentifier: isJSXIdentifier5,
+      isJSXIdentifier: isJSXIdentifier6,
       isNewExpression,
       isPlaceholder,
       isStatement,
@@ -46462,7 +46462,7 @@ var require_parse3 = __commonJS({
         hasSyntacticPlaceholders = true;
       } else if (hasSyntacticPlaceholders || state.syntacticPlaceholders) {
         return;
-      } else if (isIdentifier(node) || isJSXIdentifier5(node)) {
+      } else if (isIdentifier(node) || isJSXIdentifier6(node)) {
         name = node.name;
       } else if (isStringLiteral2(node)) {
         name = node.value;
@@ -48325,7 +48325,7 @@ var require_path2 = __commonJS({
     var _index = require_lib8();
     var _index2 = require_scope();
     var _t = require_lib3();
-    var t6 = _t;
+    var t7 = _t;
     var cache = require_cache();
     var _generator = require_lib5();
     var NodePath_ancestry = require_ancestry();
@@ -48586,9 +48586,9 @@ var require_path2 = __commonJS({
       _getKey: NodePath_family._getKey,
       _getPattern: NodePath_family._getPattern
     });
-    for (const type of t6.TYPES) {
+    for (const type of t7.TYPES) {
       const typeKey = `is${type}`;
-      const fn = t6[typeKey];
+      const fn = t7[typeKey];
       NodePath_Final.prototype[typeKey] = function(opts) {
         return fn(this.node, opts);
       };
@@ -48601,7 +48601,7 @@ var require_path2 = __commonJS({
     Object.assign(NodePath_Final.prototype, NodePath_virtual_types_validator);
     for (const type of Object.keys(virtualTypes)) {
       if (type.startsWith("_")) continue;
-      if (!t6.TYPES.includes(type)) t6.TYPES.push(type);
+      if (!t7.TYPES.includes(type)) t7.TYPES.push(type);
     }
   }
 });
@@ -48824,7 +48824,7 @@ var require_context2 = __commonJS({
     var _traverseNode = require_traverse_node();
     var _index = require_path2();
     var _removal = require_removal();
-    var t6 = require_lib3();
+    var t7 = require_lib3();
     function call(key) {
       const opts = this.opts;
       this.debug(key);
@@ -49027,7 +49027,7 @@ var require_context2 = __commonJS({
         context,
         node
       } = this;
-      if (!t6.isPrivate(node) && node.computed) {
+      if (!t7.isPrivate(node) && node.computed) {
         context.maybeQueue(this.get("key"));
       }
       if (node.decorators) {
@@ -50009,6 +50009,114 @@ function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
   return violations;
 }
 
+// ../tailwind-a11y/dist/parser/extractReducedMotion.js
+var t6 = __toESM(require_lib3(), 1);
+var TRANSITION_BASES = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
+var INTERACTION_VARIANTS = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+function baseUtility2(raw) {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+function variantSegments(raw) {
+  return raw.split(":").slice(0, -1);
+}
+function extractReducedMotionChecks(code, filePath) {
+  const ast = parseJSX(code, filePath);
+  if (!ast)
+    return [];
+  const checks = [];
+  traverse(ast, {
+    JSXElement(path) {
+      const opening = path.node.openingElement;
+      const className = getStaticClassName(opening.attributes);
+      if (!className)
+        return;
+      const classes = className.split(/\s+/).filter(Boolean);
+      const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility2(raw)));
+      const hasInteractionClass = classes.some((raw) => variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v)));
+      if (!hasTransitionBase || !hasInteractionClass)
+        return;
+      checks.push({
+        file: filePath,
+        line: opening.loc?.start.line ?? 0,
+        tagName: t6.isJSXIdentifier(opening.name) ? opening.name.name : "unknown-element",
+        classes
+      });
+    }
+  });
+  return checks;
+}
+
+// ../tailwind-a11y/dist/rules/checkReducedMotion.js
+var TRANSITION_BASES2 = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
+var INTERACTION_VARIANTS2 = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+function baseUtility3(raw) {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+function variantSegments2(raw) {
+  return raw.split(":").slice(0, -1);
+}
+var SCALE_RE = /^(scale|scale-x|scale-y)-(\d+)$/;
+var ROTATE_RE = /^-?rotate-(\d+(?:\.\d+)?)$/;
+var TRANSLATE_RE = /^-?(translate-x|translate-y)-(\d+(?:\.\d+)?)$/;
+var SKEW_RE = /^-?(skew-x|skew-y)-(\d+(?:\.\d+)?)$/;
+function isNonIdentityMotionUtility(base) {
+  const scale = SCALE_RE.exec(base);
+  if (scale)
+    return Number(scale[2]) !== 100;
+  const rotate = ROTATE_RE.exec(base);
+  if (rotate)
+    return Number(rotate[1]) !== 0;
+  const translate = TRANSLATE_RE.exec(base);
+  if (translate)
+    return Number(translate[2]) !== 0;
+  const skew = SKEW_RE.exec(base);
+  if (skew)
+    return Number(skew[2]) !== 0;
+  return false;
+}
+function checkReducedMotion(checks, strict = false) {
+  if (!strict)
+    return [];
+  const violations = [];
+  for (const check of checks) {
+    let unscopedTransition = null;
+    let hasMotionReduceGuard = false;
+    for (const raw of check.classes) {
+      const base = baseUtility3(raw);
+      const segments = variantSegments2(raw);
+      if (segments.length === 0 && TRANSITION_BASES2.has(base))
+        unscopedTransition = raw;
+      if (segments.includes("motion-reduce") && (base === "transition-none" || base === "transform-none")) {
+        hasMotionReduceGuard = true;
+      }
+    }
+    if (!unscopedTransition)
+      continue;
+    if (hasMotionReduceGuard)
+      continue;
+    const motionClass = check.classes.find((raw) => {
+      const segments = variantSegments2(raw);
+      if (segments.includes("motion-safe"))
+        return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS2.has(v)))
+        return false;
+      return isNonIdentityMotionUtility(baseUtility3(raw));
+    });
+    if (!motionClass)
+      continue;
+    violations.push({
+      type: "reduced-motion",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      transitionClass: unscopedTransition,
+      motionClass,
+      level: "AAA"
+    });
+  }
+  return violations;
+}
+
 // ../tailwind-a11y/dist/theme/loadCustomTheme.js
 var import_node_fs = require("node:fs");
 var import_node_path = require("node:path");
@@ -50318,6 +50426,8 @@ function formatViolation(v) {
       const base = `<${v.tagName}> focus indicator ${v.indicatorClass} on ${v.bgClass} \u2014 ratio ${v.ratio.toFixed(2)}, needs ${v.required} (WCAG ${sc})`;
       return v.thicknessPx !== void 0 ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px` : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard \u2014 WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 function toAnnotationCommand(v) {
@@ -50362,7 +50472,8 @@ async function main() {
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${err.message}`);

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.11.0",
+    "tailwind-a11y": "^0.12.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/src/annotations.test.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.test.ts
@@ -110,6 +110,21 @@ describe("formatViolation", () => {
       "<a> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
     );
   });
+
+  it("formats a reduced-motion violation", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      file: "src/Card.tsx",
+      line: 3,
+      tagName: "div",
+      transitionClass: "transition-transform",
+      motionClass: "hover:scale-110",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
 });
 
 describe("toAnnotationCommand", () => {

--- a/packages/github-action-tailwind-a11y/src/annotations.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.ts
@@ -1,6 +1,17 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
+import type {
+  ContrastViolation,
+  TouchTargetViolation,
+  FocusIndicatorViolation,
+  FocusContrastViolation,
+  ReducedMotionViolation,
+} from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+export type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 // GitHub renders roughly 10 annotations per type per step (and ~50 per job) --
 // undocumented, observed limits. Correctness never rides on annotations:
@@ -42,6 +53,8 @@ export function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 

--- a/packages/github-action-tailwind-a11y/src/main.ts
+++ b/packages/github-action-tailwind-a11y/src/main.ts
@@ -9,6 +9,8 @@ import {
   extractFocusIndicatorChecks,
   checkFocusIndicators,
   checkFocusContrast,
+  extractReducedMotionChecks,
+  checkReducedMotion,
   resolveTheme,
 } from "tailwind-a11y";
 import { parseInputs } from "./inputs.js";
@@ -64,7 +66,8 @@ async function main(): Promise<void> {
         ...checkContrast(extractChecks(code, file), palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
     } catch (err) {
       console.log(`tailwind-a11y: skipping unreadable file ${file}: ${(err as Error).message}`);

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -12,7 +12,8 @@ published consumers, not free pre-launch churn.)
 
 A static analysis CLI that catches WCAG accessibility violations in Tailwind
 CSS class combinations before they ship: color contrast, touch target size,
-and focus indicator removal/contrast. Existing contrast tools (e.g.
+focus indicator removal/contrast, and reduced motion for interaction-
+triggered animation. Existing contrast tools (e.g.
 `tailwindcss-contrast-checker`) only catch `text-*`/`bg-*` on the *same*
 element; this tool also catches the much more common **direct-parent**
 pattern:
@@ -225,6 +226,80 @@ Tailwind-class-level sizing or focus-style analysis).
     independently-configurable `strict` rule option (own file, own schema),
     since ESLint has no plugin-wide toggle and each rule's options are
     already independently set.
+- **Reduced motion: `checkReducedMotion(checks, strict?)` is WCAG 2.3.3
+  (AAA), the first check in this project with no AA tier to fall back to at
+  all.** Verified against the W3C Understanding doc that "motion animation"
+  specifically means a change to an element's perceived size, shape, or
+  position — color/opacity/blur changes don't qualify, even though they're
+  visually "animated" in the everyday sense. This is why `animate-spin`/
+  `-ping`/`-pulse`/`-bounce` are deliberately **not** covered here: they're
+  continuous, not interaction-triggered, so they belong under 2.2.2 (Pause,
+  Stop, Hide) instead, which has a materially different, harder-to-
+  statically-verify requirement (a 5-second-or-longer duration threshold
+  this tool has no way to know) — folding them in here would misattribute
+  the wrong SC. **Known gap, not yet closed**: that reasoning only holds for
+  an *unscoped* `animate-*` (always running). An interaction-scoped one
+  (`hover:animate-bounce` — a translateY-based, genuinely position-changing
+  animation per the Understanding doc's own definition, triggered only by
+  hover) is squarely 2.3.3's territory per the doc's own "not in response to
+  an intentional user activation" distinction for 2.2.2 — caught in
+  independent review, not yet implemented. The extractor's candidacy gate
+  requires a `transition`/`transition-all`/`transition-transform` base,
+  which `animate-*` isn't, so `hover:animate-bounce` alone currently
+  produces zero checks in any mode, not by deliberate design for this
+  specific case. Would need its own detection path (`animate-*` utilities
+  don't need a `transition-*` base to animate — they carry their own
+  `animation` property), not an extension of the transition-based logic
+  here.
+  - Because there's no AA tier, this is gated behind `strict` in every
+    scan-everything-by-default adapter (CLI, VS Code, GitHub Action) — an
+    AAA-only check running unconditionally would silently start failing
+    existing users' CI on a routine upgrade, unlike the genuinely-AA
+    `checkFocusIndicators` (2.4.7), the one other check in this file with no
+    strict tier. The ESLint rule is the one exception: enabling
+    `tailwind-a11y/reduced-motion` in a config is itself the opt-in
+    gesture, so it always checks for real (`schema: []`, no option, same as
+    `focus-indicator.ts`) — and it's deliberately **not** included in
+    `configs.recommended` either, for the same "AAA shouldn't silently ride
+    along with an AA baseline" reason.
+  - Not scoped to `isInteractiveElement()` — the Understanding doc's own
+    examples aren't limited to buttons/links (a plain hover-animated `<div>`
+    card is exactly the target case), so it walks every JSX element with a
+    static `className`, same as `extractClasses.ts`'s contrast check.
+    Interaction variants recognized: `hover`/`focus`/`focus-visible`/
+    `focus-within`/`active`.
+  - Variant detection scans **every** segment of a stacked variant class
+    (`variantSegments()`), not just the one immediately before the base
+    utility — caught in independent review: `motion-safe:hover:scale-110`
+    and `hover:motion-safe:scale-110` compile to the identical nested media
+    query (verified against a real v4 build), so checking only the
+    innermost segment made the original implementation order-dependent —
+    it recognized the interaction variant, or a `motion-safe:` self-guard on
+    the motion utility itself, only when written last, silently missing the
+    equally valid reverse ordering. Fixed by checking membership across the
+    whole variant stack instead of a single position, in both the extractor
+    and the rule.
+  - Only `transition`/`transition-all`/`transition-transform` count as a
+    qualifying transition base — verified against a real Tailwind v4 build
+    that these three are the only ones whose `transition-property` list
+    includes `transform`/`translate`/`scale`/`rotate`; `transition-colors`/
+    `-opacity`/`-shadow` don't, so a `scale-*` change under `hover:` on an
+    element with only one of those never actually animates (nothing tells
+    the browser to transition that property), and correctly isn't flagged.
+    The transition must be **unscoped** (not itself behind `hover:`/etc.) —
+    a variant-scoped transition isn't present in the resting state, so the
+    browser has nothing to transition from when the interaction begins.
+  - `motion-safe:`-scoping the transition instead of leaving it unscoped is
+    treated as a complete, alternative way of satisfying 2.3.3 (one of the
+    three approaches the Understanding doc names), not a partial one — the
+    transition simply doesn't exist unless motion is already safe.
+  - Each transform utility's identity value is excluded (`scale-100`,
+    `rotate-0`, `translate-x-0`/`-y-0`, `skew-x-0`/`-y-0`, either sign) —
+    real utilities that move nothing, the same "shape looks real but isn't"
+    failure class noted below. Arbitrary bracket values (`scale-[1.5]`) and
+    3D transform utilities (`rotate-x-*`, `translate-z-*`, confirmed to
+    exist in a real v4 build) are out of scope for v1 — unmatched, so
+    silently not considered "motion" rather than guessed at.
 - **Contrast: opacity modifiers (`text-gray-400/50`) are resolved on the
   *text* side only**, composited against the already-resolved (fully opaque)
   background — see `resolveTextColorWithOpacity()`/`applyAlpha()` in
@@ -277,6 +352,7 @@ src/
   parser/extractClasses.ts        — text-*/bg-* pairs per element (contrast)
   parser/extractTouchTargets.ts   — w-*/h-* pairs on interactive elements
   parser/extractFocusIndicators.ts— focus:/focus-visible: classes on interactive elements
+  parser/extractReducedMotion.ts  — transition + hover:/focus:/active: classes on any element
   rules/checkContrast.ts          — contrast violations (WCAG 1.4.3, AA);
                                      resolves a text-side opacity modifier
                                      against the resolved (opaque) bg; also
@@ -288,7 +364,9 @@ src/
   rules/checkFocusIndicator.ts    — focus indicator removal (WCAG 2.4.7, AA)
                                      and focus indicator contrast (WCAG
                                      1.4.11 AA / 2.4.13 AAA under strict)
-  cli.ts                         — fast-glob scan, run all four checkers,
+  rules/checkReducedMotion.ts     — reduced motion violations (WCAG 2.3.3,
+                                     AAA-only, gated behind strict)
+  cli.ts                         — fast-glob scan, run all five checkers,
                                     print report, exit 1 on any violations (CI)
   cliArgs.ts                     — flag parsing, including --config <path>
 ```

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -25,7 +25,7 @@ npm install --save-dev tailwind-a11y
 npx tailwind-a11y                              # scans **/*.{jsx,tsx}
 npx tailwind-a11y "src/**/*.tsx"               # custom glob
 npx tailwind-a11y --verbose                    # also reports what couldn't be checked, and why
-npx tailwind-a11y --strict                     # touch targets: WCAG 2.5.5 (AAA, 44x44px); focus indicators: also WCAG 2.4.13 (AAA, min thickness)
+npx tailwind-a11y --strict                     # AAA tier: touch targets 2.5.5, focus indicators also 2.4.13, and enables the reduced-motion check (2.3.3)
 npx tailwind-a11y --config ./tw.config.cjs     # use a specific config instead of auto-detecting
 npx tailwind-a11y --version                    # print the installed version
 npx tailwind-a11y --help                       # usage and all options
@@ -57,6 +57,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |
+| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
 
 ## Scope
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -14,6 +14,8 @@ import {
   type FocusContrastViolation,
   type FocusIndicatorViolation,
 } from "./rules/checkFocusIndicator.js";
+import { extractReducedMotionChecks } from "./parser/extractReducedMotion.js";
+import { checkReducedMotion, type ReducedMotionViolation } from "./rules/checkReducedMotion.js";
 import { parseArgs, getHelpText } from "./cliArgs.js";
 import { resolveTheme } from "./theme/loadCustomTheme.js";
 
@@ -21,7 +23,12 @@ import { resolveTheme } from "./theme/loadCustomTheme.js";
 const require = createRequire(import.meta.url);
 const { version: packageVersion } = require("../package.json") as { version: string };
 
-type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 interface Skip {
   file: string;
@@ -48,6 +55,8 @@ function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `${v.line}: <${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 
@@ -115,7 +124,8 @@ async function main(): Promise<void> {
         ...checkContrast(contrastChecks, palette),
         ...checkTouchTargets(extractTouchTargetChecks(code, file, spacing), strict),
         ...checkFocusIndicators(focusChecks),
-        ...checkFocusContrast(focusChecks, strict, palette)
+        ...checkFocusContrast(focusChecks, strict, palette),
+        ...checkReducedMotion(extractReducedMotionChecks(code, file), strict)
       );
 
       if (verbose) {

--- a/packages/tailwind-a11y/src/cliArgs.ts
+++ b/packages/tailwind-a11y/src/cliArgs.ts
@@ -14,7 +14,8 @@ export interface ParsedArgs {
 const HELP_TEXT = `Usage: tailwind-a11y [options] [<glob>...]
 
 Static analysis for Tailwind CSS accessibility violations -- color contrast,
-touch target size, and focus indicator removal/contrast.
+touch target size, focus indicator removal/contrast, and reduced-motion
+support for interaction-triggered animation.
 
 Options:
   -v, --verbose      Also report what couldn't be checked, and why
@@ -23,7 +24,10 @@ Options:
       --strict       Touch targets must meet WCAG 2.5.5 (AAA, 44x44px)
                       instead of the default 2.5.8 (AA, 24x24px); focus
                       indicators are also held to 2.4.13 (AAA, minimum
-                      thickness) alongside the default 1.4.11 (AA, contrast)
+                      thickness) alongside the default 1.4.11 (AA, contrast);
+                      also enables the reduced-motion check (WCAG 2.3.3,
+                      AAA-only, off by default -- has no AA tier to fall
+                      back to)
       --config <path>  Path to a tailwind.config.js/.cjs (v3) or a CSS
                         @theme file like app/globals.css (v4) to read
                         custom theme colors/spacing from (default:

--- a/packages/tailwind-a11y/src/index.ts
+++ b/packages/tailwind-a11y/src/index.ts
@@ -9,6 +9,8 @@ export {
   type FocusIndicatorViolation,
   type FocusContrastViolation,
 } from "./rules/checkFocusIndicator.js";
+export { extractReducedMotionChecks, type ReducedMotionCheck } from "./parser/extractReducedMotion.js";
+export { checkReducedMotion, type ReducedMotionViolation } from "./rules/checkReducedMotion.js";
 export { hexToRgb, contrastRatio, meetsWCAG, requiredRatio, type RGB } from "./contrast/luminance.js";
 export {
   resolveTheme,

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { extractReducedMotionChecks } from "./extractReducedMotion.js";
+
+describe("extractReducedMotionChecks", () => {
+  it("collects an element with a transition base and an interaction-scoped class", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    const checks = extractReducedMotionChecks(code, "fake.tsx");
+    expect(checks).toEqual([
+      {
+        file: "fake.tsx",
+        line: 1,
+        tagName: "div",
+        classes: ["transition-transform", "hover:scale-110"],
+      },
+    ]);
+  });
+
+  it("is not scoped to interactive elements -- a plain div qualifies", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("skips an element with a transition base but no interaction-scoped class", () => {
+    const code = `const C = () => <div className="transition-transform">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("skips an element with an interaction-scoped class but no transition base", () => {
+    const code = `const C = () => <div className="hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("still collects when the only transition base is motion-safe:-scoped (rule decides pass/fail)", () => {
+    const code = `const C = () => <div className="motion-safe:transition-transform hover:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  // Caught in independent review: variant order shouldn't matter --
+  // motion-safe:hover:scale-110 and hover:motion-safe:scale-110 compile to
+  // the same nested media query (verified against a real Tailwind v4
+  // build), so both must be recognized as interaction-scoped, not just
+  // whichever one happens to put the interaction variant last.
+  it.each(["motion-safe:hover:scale-110", "hover:motion-safe:scale-110"])(
+    "recognizes an interaction variant regardless of its position in a stacked variant, e.g. %s",
+    (stackedClass) => {
+      const code = `const C = () => <div className="transition-transform ${stackedClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+    }
+  );
+
+  it("recognizes focus-within: as an interaction variant", () => {
+    const code = `const C = () => <div className="transition-transform focus-within:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it("skips dynamic className without throwing", () => {
+    const code = `const C = ({ x }) => <div className={x ? 'transition-transform hover:scale-110' : ''}>x</div>;`;
+    expect(() => extractReducedMotionChecks(code, "fake.tsx")).not.toThrow();
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+});

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
@@ -1,0 +1,72 @@
+import * as t from "@babel/types";
+import { getStaticClassName, parseJSX, traverse } from "./babelInterop.js";
+
+export interface ReducedMotionCheck {
+  file: string;
+  line: number;
+  tagName: string;
+  // All classes on the element, unfiltered -- checkReducedMotion.ts does
+  // the shape/variant/identity-value classification (unscoped vs
+  // motion-safe:-scoped transition, motion-reduce:-scoped guards,
+  // interaction-scoped transform values), same "extractor collects
+  // broadly, rule filters narrowly" split as extractFocusIndicators.ts/
+  // checkFocusIndicator.ts.
+  classes: string[];
+}
+
+const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
+const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+function baseUtility(raw: string): string {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+
+// Every variant applied to a class, in source order -- NOT just the one
+// immediately before the base utility. Caught in independent review:
+// Tailwind variants stack (`motion-safe:hover:scale-110` and
+// `hover:motion-safe:scale-110` compile to the identical nested media query,
+// confirmed against a real v4 build), so checking only the innermost
+// segment made this extractor's own candidacy gate order-dependent -- it
+// would only recognize the interaction variant when it happened to be
+// written last, silently missing the equally valid `hover:motion-safe:...`
+// ordering. checkReducedMotion.ts uses the same helper for the same reason.
+function variantSegments(raw: string): string[] {
+  return raw.split(":").slice(0, -1);
+}
+
+export function extractReducedMotionChecks(code: string, filePath: string): ReducedMotionCheck[] {
+  const ast = parseJSX(code, filePath);
+  if (!ast) return [];
+
+  const checks: ReducedMotionCheck[] = [];
+
+  traverse(ast, {
+    JSXElement(path) {
+      const opening = path.node.openingElement;
+      const className = getStaticClassName(opening.attributes);
+      if (!className) return;
+
+      const classes = className.split(/\s+/).filter(Boolean);
+
+      const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility(raw)));
+      const hasInteractionClass = classes.some((raw) =>
+        variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v))
+      );
+      // Not a candidate at all unless there's some transition utility
+      // (scoped or not) *and* some interaction-scoped class -- narrows the
+      // set of elements checkReducedMotion.ts has to reason about, without
+      // pre-deciding any of the nuance (unscoped vs motion-safe:, identity
+      // values, motion-reduce: guards) that belongs in the rule.
+      if (!hasTransitionBase || !hasInteractionClass) return;
+
+      checks.push({
+        file: filePath,
+        line: opening.loc?.start.line ?? 0,
+        tagName: t.isJSXIdentifier(opening.name) ? opening.name.name : "unknown-element",
+        classes,
+      });
+    },
+  });
+
+  return checks;
+}

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { checkReducedMotion } from "./checkReducedMotion.js";
+import { extractReducedMotionChecks } from "../parser/extractReducedMotion.js";
+
+function check(classes: string[]) {
+  return { file: "f.tsx", line: 1, tagName: "div", classes };
+}
+
+describe("checkReducedMotion", () => {
+  it("reports nothing by default (strict not passed) even for an otherwise-real violation", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])]);
+    expect(violations).toEqual([]);
+  });
+
+  it("reports nothing when strict is explicitly false", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])], false);
+    expect(violations).toEqual([]);
+  });
+
+  it("flags an unscoped transition-transform with an interaction-scoped scale and no guard, under strict", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([
+      {
+        type: "reduced-motion",
+        file: "f.tsx",
+        line: 1,
+        tagName: "div",
+        transitionClass: "transition-transform",
+        motionClass: "hover:scale-110",
+        level: "AAA",
+      },
+    ]);
+  });
+
+  it("passes when a motion-reduce:transition-none guard is present", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-reduce:transition-none"])],
+      true
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("passes when a motion-reduce:transform-none guard is present", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-reduce:transform-none"])],
+      true
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it("passes when the transition is scoped under motion-safe: instead of unscoped (complete alternative)", () => {
+    const violations = checkReducedMotion([check(["motion-safe:transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  // Caught in independent review: motion-safe:hover:scale-110 and
+  // hover:motion-safe:scale-110 compile to the identical nested media query
+  // (confirmed against a real Tailwind v4 build) -- both must be treated as
+  // "this motion utility only applies when motion is already safe,"
+  // regardless of which variant was written first.
+  it.each(["motion-safe:hover:scale-110", "hover:motion-safe:scale-110"])(
+    "passes when the interaction-scoped motion utility is itself motion-safe:-guarded, in either variant order: %s",
+    (motionClass) => {
+      const violations = checkReducedMotion([check(["transition-transform", motionClass])], true);
+      expect(violations).toEqual([]);
+    }
+  );
+
+  it("still flags a plain hover:scale-110 (no motion-safe: anywhere) alongside an unrelated motion-safe:-guarded class", () => {
+    const violations = checkReducedMotion(
+      [check(["transition-transform", "hover:scale-110", "motion-safe:hover:rotate-3"])],
+      true
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0].motionClass).toBe("hover:scale-110");
+  });
+
+  it("recognizes focus-within: as an interaction variant", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "focus-within:scale-110"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("does not flag transition-colors -- it doesn't animate transform/scale/rotate/translate", () => {
+    const violations = checkReducedMotion([check(["transition-colors", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("bare transition (the default property list) still counts -- it includes transform/scale/rotate/translate", () => {
+    const violations = checkReducedMotion([check(["transition", "hover:scale-110"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("transition-all still counts", () => {
+    const violations = checkReducedMotion([check(["transition-all", "hover:rotate-45"])], true);
+    expect(violations).toHaveLength(1);
+  });
+
+  it.each(["hover:scale-100", "focus:rotate-0", "active:translate-x-0", "hover:-translate-y-0", "focus-visible:skew-x-0"])(
+    "does not flag an identity-value interaction utility: %s",
+    (identity) => {
+      const violations = checkReducedMotion([check(["transition-transform", identity])], true);
+      expect(violations).toEqual([]);
+    }
+  );
+
+  it.each(["hover:scale-110", "hover:scale-x-125", "focus:rotate-3", "active:-rotate-6", "hover:-translate-y-1", "focus-visible:skew-x-6"])(
+    "flags a real, non-identity interaction motion utility: %s",
+    (motion) => {
+      const violations = checkReducedMotion([check(["transition-transform", motion])], true);
+      expect(violations).toHaveLength(1);
+    }
+  );
+
+  it("does not flag when there's a transition but no interaction-scoped motion utility at all", () => {
+    const violations = checkReducedMotion([check(["transition-transform", "hover:bg-blue-500"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("does not flag when the transition itself is hover-scoped (not present in the resting state)", () => {
+    const violations = checkReducedMotion([check(["hover:transition-transform", "hover:scale-110"])], true);
+    expect(violations).toEqual([]);
+  });
+
+  it("composes end-to-end with extractReducedMotionChecks", () => {
+    const code = `const C = () => <div className="transition-transform hover:scale-110">x</div>;`;
+    const violations = checkReducedMotion(extractReducedMotionChecks(code, "fake.tsx"), true);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].type).toBe("reduced-motion");
+  });
+});

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
@@ -1,0 +1,124 @@
+import type { ReducedMotionCheck } from "../parser/extractReducedMotion.js";
+
+export interface ReducedMotionViolation {
+  type: "reduced-motion";
+  file: string;
+  line: number;
+  tagName: string;
+  transitionClass: string;
+  motionClass: string;
+  level: "AAA"; // no AA tier exists for this SC to fall back to
+}
+
+// Verified against a real Tailwind v4 build: only these three include
+// transform/translate/scale/rotate in their transition-property list.
+// transition-colors/-opacity/-shadow don't -- so a scale/rotate/translate
+// change under hover on an element with only one of those never actually
+// animates (the browser has nothing telling it to transition that
+// property), and correctly isn't flagged.
+const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
+const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+function baseUtility(raw: string): string {
+  return raw.slice(raw.lastIndexOf(":") + 1);
+}
+
+// Every variant applied to a class, in source order -- see the identical
+// helper (and full explanation) in extractReducedMotion.ts. Duplicated
+// rather than imported, matching this codebase's own established
+// precedent of small per-file primitives (e.g. checkFocusIndicator.ts's own
+// baseUtility is separate from extractFocusIndicators.ts's).
+function variantSegments(raw: string): string[] {
+  return raw.split(":").slice(0, -1);
+}
+
+// Positive shape filter, not a denylist -- same reasoning as COLOR_TOKEN in
+// extractClasses.ts. Excludes each utility's identity value (scale-100,
+// rotate-0, translate-x-0/-y-0, skew-x-0/-y-0), since those utilities are
+// real but move nothing -- flagging them would be a false positive, the
+// same "shape looks real but isn't" failure class this project has hit
+// before. Arbitrary bracket values (scale-[1.5]) and 3D transform utilities
+// (rotate-x-*, translate-z-*, ...) are out of scope for v1 -- unmatched, so
+// silently not considered "motion" here rather than guessed at.
+const SCALE_RE = /^(scale|scale-x|scale-y)-(\d+)$/;
+const ROTATE_RE = /^-?rotate-(\d+(?:\.\d+)?)$/;
+const TRANSLATE_RE = /^-?(translate-x|translate-y)-(\d+(?:\.\d+)?)$/;
+const SKEW_RE = /^-?(skew-x|skew-y)-(\d+(?:\.\d+)?)$/;
+
+function isNonIdentityMotionUtility(base: string): boolean {
+  const scale = SCALE_RE.exec(base);
+  if (scale) return Number(scale[2]) !== 100;
+  const rotate = ROTATE_RE.exec(base);
+  if (rotate) return Number(rotate[1]) !== 0;
+  const translate = TRANSLATE_RE.exec(base);
+  if (translate) return Number(translate[2]) !== 0;
+  const skew = SKEW_RE.exec(base);
+  if (skew) return Number(skew[2]) !== 0;
+  return false;
+}
+
+// `strict` gates the whole check for the scan-everything-by-default
+// adapters (CLI/VS Code/GitHub Action) -- WCAG 2.3.3 is AAA-only, and
+// unconditionally enabling a brand-new AAA check would silently start
+// failing existing users' CI on a routine upgrade, unlike a genuine AA
+// baseline (2.4.7's focus-indicator check, the one other check in this file
+// with no strict tier). Consistent with this project's own `strict` =
+// "hold every check to its AAA tier where one exists" framing. The ESLint
+// rule is the one caller that always passes `true` regardless -- enabling
+// `tailwind-a11y/reduced-motion` in an ESLint config is itself the opt-in
+// gesture there, so a second gate on top would just make the rule silently
+// report nothing when a user enabled it expecting it to check something.
+export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false): ReducedMotionViolation[] {
+  if (!strict) return [];
+
+  const violations: ReducedMotionViolation[] = [];
+
+  for (const check of checks) {
+    let unscopedTransition: string | null = null;
+    let hasMotionReduceGuard = false;
+
+    for (const raw of check.classes) {
+      const base = baseUtility(raw);
+      const segments = variantSegments(raw);
+
+      if (segments.length === 0 && TRANSITION_BASES.has(base)) unscopedTransition = raw;
+
+      if (segments.includes("motion-reduce") && (base === "transition-none" || base === "transform-none")) {
+        hasMotionReduceGuard = true;
+      }
+    }
+
+    // A transition scoped only under motion-safe: (never unscoped) means it
+    // simply doesn't exist unless motion is already safe -- a complete
+    // alternative way of satisfying 2.3.3, not a partial one -- so this
+    // correctly falls through as a pass, not a skip-because-unresolvable.
+    if (!unscopedTransition) continue;
+    if (hasMotionReduceGuard) continue;
+
+    const motionClass = check.classes.find((raw) => {
+      const segments = variantSegments(raw);
+      // motion-safe: anywhere in this specific class's own variant stack
+      // means the motion utility itself doesn't apply unless motion is
+      // already safe -- the same complete-alternative reasoning as the
+      // transition side above, just checked per-candidate instead of once
+      // for the whole element (a class can be interaction-scoped *and*
+      // self-guarded at the same time, e.g. `hover:motion-safe:scale-110`).
+      if (segments.includes("motion-safe")) return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS.has(v))) return false;
+      return isNonIdentityMotionUtility(baseUtility(raw));
+    });
+    if (!motionClass) continue; // no real, un-self-guarded motion actually triggered by interaction
+
+    violations.push({
+      type: "reduced-motion",
+      file: check.file,
+      line: check.line,
+      tagName: check.tagName,
+      transitionClass: unscopedTransition,
+      motionClass,
+      level: "AAA",
+    });
+  }
+
+  return violations;
+}

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -15,6 +15,7 @@ reimplemented here.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |
+| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
 (debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)
@@ -32,9 +33,11 @@ setting:
 ```
 
 Set `tailwind-a11y.strict` to enforce the stricter 44×44px touch target
-minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA), and to
+minimum (WCAG 2.5.5, AAA) instead of the default 24×24px (2.5.8, AA), to
 also require focus indicators to meet WCAG 2.4.13's minimum thickness
-alongside the always-on 3:1 contrast check (1.4.11):
+alongside the always-on 3:1 contrast check (1.4.11), and to enable the
+reduced-motion check (WCAG 2.3.3, AAA-only, off unless `strict` is set —
+there's no AA tier for it to fall back to):
 
 ```json
 { "tailwind-a11y.strict": true }

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -41,7 +41,7 @@
           "type": "boolean",
           "default": false,
           "scope": "resource",
-          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), and WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check."
+          "description": "Enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check, and the reduced-motion check (WCAG 2.3.3, AAA-only, off by default -- has no AA tier to fall back to)."
         }
       }
     }
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.11.0"
+    "tailwind-a11y": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/extension.ts
+++ b/packages/vscode-tailwind-a11y/src/extension.ts
@@ -7,6 +7,8 @@ import {
   extractFocusIndicatorChecks,
   checkFocusIndicators,
   checkFocusContrast,
+  extractReducedMotionChecks,
+  checkReducedMotion,
   resolveTheme,
 } from "tailwind-a11y";
 import { formatViolation, type AnyViolation } from "./format.js";
@@ -96,6 +98,7 @@ function analyze(doc: vscode.TextDocument): vscode.Diagnostic[] {
     ...checkTouchTargets(extractTouchTargetChecks(text, file, spacing), strict),
     ...checkFocusIndicators(focusChecks),
     ...checkFocusContrast(focusChecks, strict, palette),
+    ...checkReducedMotion(extractReducedMotionChecks(text, file), strict),
   ];
 
   return violations.map((v) => {

--- a/packages/vscode-tailwind-a11y/src/format.test.ts
+++ b/packages/vscode-tailwind-a11y/src/format.test.ts
@@ -110,4 +110,19 @@ describe("formatViolation", () => {
       "<button> focus indicator focus:ring-white on bg-blue-500 — ratio 3.68, needs 3 (WCAG 2.4.13); also only 1px thick, needs >= 2px"
     );
   });
+
+  it("formats a reduced-motion violation", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      file: "f.tsx",
+      line: 1,
+      tagName: "div",
+      transitionClass: "transition-transform",
+      motionClass: "hover:scale-110",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
 });

--- a/packages/vscode-tailwind-a11y/src/format.ts
+++ b/packages/vscode-tailwind-a11y/src/format.ts
@@ -1,6 +1,17 @@
-import type { ContrastViolation, TouchTargetViolation, FocusIndicatorViolation, FocusContrastViolation } from "tailwind-a11y";
+import type {
+  ContrastViolation,
+  TouchTargetViolation,
+  FocusIndicatorViolation,
+  FocusContrastViolation,
+  ReducedMotionViolation,
+} from "tailwind-a11y";
 
-export type AnyViolation = ContrastViolation | TouchTargetViolation | FocusIndicatorViolation | FocusContrastViolation;
+export type AnyViolation =
+  | ContrastViolation
+  | TouchTargetViolation
+  | FocusIndicatorViolation
+  | FocusContrastViolation
+  | ReducedMotionViolation;
 
 // Mirrors cli.ts's formatViolation, minus the leading "${line}: " prefix —
 // VS Code renders the diagnostic's location itself. Kept in its own module
@@ -25,5 +36,7 @@ export function formatViolation(v: AnyViolation): string {
         ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px`
         : base;
     }
+    case "reduced-motion":
+      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }


### PR DESCRIPTION
## What

New check: an element with an unscoped `transition`/`transition-all`/`transition-transform` and a `hover:`/`focus:`/`focus-visible:`/`focus-within:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change (excluding each utility's identity value, like `scale-100` or `rotate-0`) gets flagged unless it has a `motion-reduce:transition-none`/`transform-none` guard, or the transition itself is scoped under `motion-safe:` instead. Verified against the W3C Understanding doc that "motion animation" under 2.3.3 means a size/shape/position change specifically, not color or opacity -- and against a real Tailwind v4 build for exactly which `transition-*` utilities actually include transform in their property list (`transition-colors`/`-opacity`/`-shadow` don't, so those correctly never fire this check).

`animate-spin`/`-ping`/`-pulse`/`-bounce` are deliberately out of scope here -- they're continuous, not interaction-triggered, so an unscoped one belongs under 2.2.2 (Pause, Stop, Hide) instead, which has a different and harder-to-statically-verify requirement (a duration threshold this tool has no way to know).

## Why this is gated behind `strict`, unlike every check before it

2.3.3 is AAA with no AA tier to fall back to. Every other check in this project defaults to an AA baseline and only reaches AAA under `--strict`. Making this one unconditional would mean a routine upgrade silently starts failing CI for every existing CLI/VS Code/GitHub Action user, for a criterion the project has never required before -- so it's off by default and only runs under `strict` in those three. The ESLint rule is the exception: enabling `tailwind-a11y/reduced-motion` in a config is itself the opt-in, so it always checks for real once added, and it's deliberately left out of `configs.recommended`.

## What review caught

A real false positive, before this shipped: variant detection only looked at the segment immediately before the base utility, so `motion-safe:hover:scale-110` and `hover:motion-safe:scale-110` -- which compile to the exact same nested media query -- were treated inconsistently, one flagged and the other not. Fixed by scanning the whole variant stack instead of a single position. Also added `focus-within:` to the recognized interaction variants (a common card hover/focus pattern that was previously invisible to this check), and documented a known, not-yet-fixed gap: an interaction-scoped `animate-*` like `hover:animate-bounce` is squarely 2.3.3's territory too, but isn't detected yet, since the extractor's candidacy gate requires a `transition-*` base that `animate-*` utilities don't have.

## Versions

Engine, eslint-plugin, and the GitHub Action go 0.11.0 -> 0.12.0. VS Code goes 0.12.0 -> 0.13.0.

## Test plan

- [x] Full test suite passes across all four packages (399 tests), including regression coverage for the variant-order bug found in review
- [x] Manual CLI smoke tests: an unguarded `transition-transform` + `hover:scale-110` reports nothing by default and is flagged only under `--strict`; a `motion-reduce:transform-none` guard, a `motion-safe:`-scoped transition, and a `transition-colors`-only element all correctly pass in every mode
- [x] Re-ran the exact false-positive repro from review after the fix -- both variant orderings now correctly resolve to zero violations
- [x] GitHub Action bundle rebuilt and confirmed non-stale
- [x] Independent review pass, with a real bug found, fixed, and re-verified