### PR TITLE
Support tailwind.config.mjs for custom theme colors/spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.12.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.13.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.12.0"
+        "tailwind-a11y": "^0.13.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.12.0"
+        "tailwind-a11y": "^0.13.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.12.0"
+        "tailwind-a11y": "^0.13.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -52,7 +52,7 @@ Exact scope and known limitations: [engine README](https://github.com/chamroro/t
 
 ## Custom theme
 
-A `tailwind.config.js`/`.cjs` (Tailwind v3) or a CSS `@theme` file like
+A `tailwind.config.js`/`.cjs`/`.mjs` (Tailwind v3) or a CSS `@theme` file like
 `app/globals.css` (Tailwind v4) in ESLint's cwd is auto-detected; point at a specific
 file instead via `settings`:
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.12.0"
+    "tailwind-a11y": "^0.13.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/README.md
+++ b/packages/github-action-tailwind-a11y/README.md
@@ -28,7 +28,7 @@ found (configurable below).
 | Input | Default | Description |
 |---|---|---|
 | `patterns` | `**/*.{jsx,tsx}` | Whitespace/newline-separated glob pattern(s) to scan |
-| `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
+| `config` | auto-detect | Path to a `tailwind.config.js`/`.cjs`/`.mjs` (v3) or CSS `@theme` file (v4) for custom theme colors/spacing |
 | `fail-on-violations` | `"true"` | Set `"false"` to annotate without failing the job |
 | `strict` | `"false"` | Set `"true"` to enforce WCAG 2.5.5 (AAA, 44x44px) touch targets instead of the default 2.5.8 (AA, 24x24px), WCAG 2.4.13's minimum focus-indicator thickness alongside the always-on 1.4.11 (AA) contrast check, and the reduced-motion check (WCAG 2.3.3, AAA-only, off by default) |
 

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -50275,7 +50275,7 @@ function parseThemeCss(cssText) {
 }
 
 // ../tailwind-a11y/dist/theme/loadCustomTheme.js
-var CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
+var CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs", "tailwind.config.mjs"];
 function findTailwindConfig(rootDir) {
   for (const filename of CONFIG_FILENAMES) {
     const candidate = (0, import_node_path.join)(rootDir, filename);
@@ -50315,7 +50315,8 @@ function loadCustomTheme(configPath) {
     const cached = require2.cache[resolved];
     if (cached)
       bustRequireCache(require2, cached, /* @__PURE__ */ new Set());
-    const config = require2(resolved);
+    const loaded = require2(resolved);
+    const config = resolved.endsWith(".mjs") && loaded && typeof loaded === "object" ? loaded.default : loaded;
     const extend = config?.theme?.extend ?? {};
     const result = {};
     if (extend.colors && typeof extend.colors === "object") {

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.12.0",
+    "tailwind-a11y": "^0.13.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -51,13 +51,45 @@ Tailwind-class-level sizing or focus-style analysis).
 - **Custom theme extension *is* implemented for both Tailwind v3 JS configs
   and v4 CSS `@theme` configs** (see `theme/loadCustomTheme.ts` and
   `theme/parseThemeCss.ts`), but narrowly:
-  - JS path: `tailwind.config.js`/`.cjs` only, reads only
+  - JS path: `tailwind.config.js`/`.cjs`/`.mjs`, reads only
     `theme.extend.colors`/`theme.extend.spacing` — never a full
-    `theme.colors`/`theme.spacing` replacement. No `.mjs`/`.ts` config files
-    (no config-transpiling dependency exists in this package, and none is
-    being added just for this). A `.js` config inside a `"type": "module"`
-    project throws `ERR_REQUIRE_ESM` on `require()` — caught, treated the
-    same as "no config found," not a crash.
+    `theme.colors`/`theme.spacing` replacement. A `.js` config inside a
+    `"type": "module"` project throws `ERR_REQUIRE_ESM` on `require()` —
+    caught, treated the same as "no config found," not a crash.
+  - `.mjs` support (added after initially being ruled out) works via plain
+    `require()` — verified that Node 20.19+/22.13+ can `require()` an ESM
+    module **synchronously**, no `import()`, no async refactor needed.
+    `require()` returns the module namespace object
+    (`{ __esModule: true, default: <export>, ... }`), unwrapped with a
+    one-line check in `loadCustomTheme.ts` before reading `theme.extend`
+    that a plain `module.exports = {...}` CJS config never accidentally
+    matches. On an older Node this throws `ERR_REQUIRE_ESM`, already caught
+    above — the same graceful "no config found" fallback, not a crash.
+    Every adapter's actual runtime already clears the threshold: the
+    GitHub Action runs on Node 24 (`action.yml`), the ESLint plugin's own
+    `engines.node` already excludes every version that lacks this, and the
+    CLI's broad `>=18` floor just degrades safely on anything older.
+    **Known limitation, not fixed**: `bustRequireCache()`'s cache-busting,
+    which is what lets a long-lived process (the VS Code extension host)
+    pick up a `.js`/`.cjs`/`.css` config edit without restarting, does
+    **not** work for `.mjs` — Node caches a synchronously-required ESM
+    module in its own internal registry, not (only) `require.cache`,
+    confirmed with a real edit-and-reload test. CLI/GitHub Action are
+    unaffected (fresh process per run); editing a `.mjs` config in VS Code
+    requires reloading the window.
+  - `.ts` config files are a deliberate non-goal, not a "not yet." Node's
+    native TypeScript type-stripping only activates when the *host* process
+    itself is launched with `--experimental-strip-types` — verified this
+    session that a library has no way to turn this on for the user, so the
+    only way to support `.ts` transparently would be promoting `esbuild`
+    from a devDependency to a genuine runtime dependency of this package, a
+    real native-binary weight increase. Also verified: a fresh
+    `create-next-app --typescript --tailwind` no longer generates any
+    JS/TS config file at all — current Tailwind v4 projects put theme
+    customization in a CSS `@theme` block instead (already fully supported,
+    see the CSS path below), so `.ts` config support would only help a
+    shrinking population of legacy v3-plus-TypeScript projects — declined
+    as not worth the dependency.
   - CSS path: reads `--color-{name}-{shade}`/`--spacing-{token}` custom
     properties out of `@theme { ... }` blocks (any modifier keyword, e.g.
     `@theme inline { ... }`, is accepted — the declaration syntax inside is

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -34,7 +34,7 @@ npx tailwind-a11y --help                       # usage and all options
 Custom theme colors/spacing are read automatically, so colors and spacing outside
 Tailwind's defaults resolve too — not just the built-in palette. Both config formats
 are supported: `theme.extend.colors`/`theme.extend.spacing` in a Tailwind v3
-`tailwind.config.js`/`.cjs`, and `--color-*`/`--spacing-*` custom properties in a
+`tailwind.config.js`/`.cjs`/`.mjs`, and `--color-*`/`--spacing-*` custom properties in a
 Tailwind v4 CSS `@theme { ... }` block (auto-detected from common paths like
 `app/globals.css`, or passed via `--config`).
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.test.ts
@@ -41,7 +41,24 @@ describe("findTailwindConfig", () => {
     expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.js"));
   });
 
-  it("returns null when neither exists", () => {
+  it("finds tailwind.config.mjs when .js and .cjs are both absent", () => {
+    writeFileSync(join(dir, "tailwind.config.mjs"), "export default {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.mjs"));
+  });
+
+  it("prefers .js over .mjs when both are present (lowest priority)", () => {
+    writeFileSync(join(dir, "tailwind.config.js"), "module.exports = {};");
+    writeFileSync(join(dir, "tailwind.config.mjs"), "export default {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.js"));
+  });
+
+  it("prefers .cjs over .mjs when both are present (lowest priority, transitively)", () => {
+    writeFileSync(join(dir, "tailwind.config.cjs"), "module.exports = {};");
+    writeFileSync(join(dir, "tailwind.config.mjs"), "export default {};");
+    expect(findTailwindConfig(dir)).toBe(join(dir, "tailwind.config.cjs"));
+  });
+
+  it("returns null when none exist", () => {
     expect(findTailwindConfig(dir)).toBeNull();
   });
 });
@@ -168,6 +185,50 @@ describe("loadCustomTheme", () => {
     const configPath = join(dir, "tailwind.config.js");
     writeFileSync(configPath, `module.exports = { theme: { extend: { spacing: { "18": "50%" } } } };`);
     expect(loadCustomTheme(configPath)).toEqual({});
+  });
+
+  it("resolves theme.extend.colors/spacing from a real .mjs (ESM) config", () => {
+    const configPath = join(dir, "tailwind.config.mjs");
+    writeFileSync(
+      configPath,
+      `export default { theme: { extend: {
+        colors: { brand: { 500: "#3490dc" } },
+        spacing: { "18": "4.5rem" },
+      } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({
+      colors: { brand: { "500": "#3490dc" } },
+      spacing: { "18": 72 },
+    });
+  });
+
+  // Caught in independent review: a structural check ("does this object
+  // have a `default` key") instead of gating strictly on the .mjs
+  // extension would silently misfire here, discarding the real theme with
+  // no error -- a .cjs config's own top-level `default` key is unrelated
+  // to Node's ESM interop shape and must never be unwrapped.
+  it("does not mistake a CJS config's own top-level `default` key for ESM interop", () => {
+    const configPath = join(dir, "tailwind.config.cjs");
+    writeFileSync(
+      configPath,
+      `module.exports = { default: "unrelated string", theme: { extend: { colors: { brand: { 500: "#3490dc" } } } } };`
+    );
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#3490dc" } } });
+  });
+
+  it("does not throw when busting the cache for a .mjs config on a second load", () => {
+    // Documented limitation, not a regression to fix here: Node's
+    // synchronous require(esm) caches the module in its own internal ESM
+    // registry, not (only) require.cache, so deleting the require.cache
+    // entry doesn't force a reload the way it does for .js/.cjs -- this
+    // only asserts the second load doesn't crash, not that it picks up
+    // the edit.
+    const configPath = join(dir, "tailwind.config.mjs");
+    writeFileSync(configPath, `export default { theme: { extend: { colors: { brand: { 500: "#111111" } } } } };`);
+    expect(loadCustomTheme(configPath)).toEqual({ colors: { brand: { "500": "#111111" } } });
+
+    writeFileSync(configPath, `export default { theme: { extend: { colors: { brand: { 500: "#222222" } } } } };`);
+    expect(() => loadCustomTheme(configPath)).not.toThrow();
   });
 
   it("reflects an edit to the same path (require cache is busted)", () => {

--- a/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
+++ b/packages/tailwind-a11y/src/theme/loadCustomTheme.ts
@@ -7,7 +7,10 @@ import { parseColorScale, parseSpacingValue } from "./themeValueParsers.js";
 import { parseThemeCss } from "./parseThemeCss.js";
 import type { Palette } from "./defaultPalette.js";
 
-const CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs"];
+// .mjs appended last (lowest priority) -- the newly-supported format behind
+// the two established ones, same "most established first" ordering
+// CSS_THEME_CANDIDATES below already uses for its own list.
+const CONFIG_FILENAMES = ["tailwind.config.js", "tailwind.config.cjs", "tailwind.config.mjs"];
 
 // v1 only looks in the given directory itself -- no ancestor-directory search.
 // --config (CLI) / settings["tailwind-a11y"].configPath (ESLint) exist as
@@ -51,14 +54,45 @@ export interface RawCustomTheme {
   spacing?: Record<string, number>;
 }
 
-// Loads a Tailwind v3-style tailwind.config.js/.cjs and extracts only
+// Loads a Tailwind v3-style tailwind.config.js/.cjs/.mjs and extracts only
 // `theme.extend.colors`/`theme.extend.spacing` -- v1 does not read a full
-// `theme.colors`/`theme.spacing` replacement, or .mjs/.ts configs (no
-// config-transpiling dependency exists in this package). Tailwind v4's
+// `theme.colors`/`theme.spacing` replacement, or .ts configs. Tailwind v4's
 // CSS-based `@theme` config is a separate format entirely, handled by
 // loadThemeFromCssFile()/parseThemeCss() below, not by this function.
 // `configPath` must be an absolute path (require() resolves relative paths
 // against this module's own location, not the caller's cwd).
+//
+// .mjs works via plain require() -- verified this session that Node
+// 20.19+/22.13+ can require() an ESM module synchronously, no import(), no
+// async refactor. On an older Node this throws ERR_REQUIRE_ESM, already
+// caught below and treated as "no config found," so this degrades exactly
+// as gracefully as it did before .mjs was supported. Every adapter's actual
+// runtime already clears the threshold: the GitHub Action runs on Node 24
+// (action.yml), eslint-plugin-tailwind-a11y's own engines.node already
+// excludes every version that lacks this, and the CLI's broad >=18 floor
+// just falls back safely on anything older.
+//
+// .ts is a deliberate non-goal, not a "not yet": Node's native TypeScript
+// type-stripping only activates when the *host* process is launched with
+// --experimental-strip-types (verified this session -- a library can't
+// turn this on for the user), so the only way to support .ts transparently
+// would be promoting esbuild from a devDependency to a real runtime
+// dependency of this package purely to transpile config files, a real
+// native-binary weight increase. Also verified this session: a fresh
+// `create-next-app --typescript --tailwind` no longer generates a JS/TS
+// config file at all -- Tailwind v4 projects put theme customization in a
+// CSS `@theme` block instead (see loadThemeFromCssFile() below), so .ts
+// config support would only help a shrinking population of legacy
+// v3-plus-TypeScript projects, not worth the dependency.
+//
+// Known limitation, not fixed: bustRequireCache() below does NOT work for
+// a .mjs config. Node's synchronous require(esm) caches the module in its
+// own internal ESM registry, not (only) in `require.cache` -- deleting the
+// `require.cache` entry doesn't force a reload, confirmed with a real
+// edit-and-reload test this session. CLI and GitHub Action are unaffected
+// (fresh process per run either way); the VS Code extension's live-reload
+// guarantee, which does work correctly for .js/.cjs/.css configs, does NOT
+// extend to .mjs -- editing a .mjs config requires reloading the window.
 //
 // Node's require() cache is busted before loading -- recursively, for the
 // config file *and* everything it required (e.g. a config that factors
@@ -90,7 +124,20 @@ export function loadCustomTheme(configPath: string): RawCustomTheme | null {
     const resolved = require.resolve(configPath);
     const cached = require.cache[resolved];
     if (cached) bustRequireCache(require, cached, new Set());
-    const config = require(resolved);
+    const loaded = require(resolved);
+    // Node's require() of an ESM module returns the module namespace object
+    // (`{ __esModule: true, default: <the actual export>, ...named exports
+    // }`), not the export itself. Gated strictly on the .mjs extension --
+    // caught in independent review: a structural check ("does it have a
+    // `default` key") instead of this would silently misfire on a genuine
+    // CJS config that happens to export its own top-level `default` key
+    // (e.g. `module.exports = { default: "unrelated", theme: {...} }`),
+    // discarding the real theme with no error. .mjs is the only path that
+    // can ever produce this wrapped shape here: a `.js`/`.cjs` require()
+    // either returns the CJS export as-is, or -- inside a "type": "module"
+    // package -- throws ERR_REQUIRE_ESM before this line is ever reached
+    // (already handled by the catch block below, and already tested).
+    const config = resolved.endsWith(".mjs") && loaded && typeof loaded === "object" ? loaded.default : loaded;
     const extend = config?.theme?.extend ?? {};
 
     const result: RawCustomTheme = {};

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -22,11 +22,14 @@ Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, a
 or [ESLint plugin](https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y)
 instead — both treat the same findings as errors.
 
-A `tailwind.config.js`/`.cjs` (Tailwind v3) or a CSS `@theme` file like
+A `tailwind.config.js`/`.cjs`/`.mjs` (Tailwind v3) or a CSS `@theme` file like
 `app/globals.css` (Tailwind v4) in the open file's workspace folder is picked up
 automatically, so custom theme colors/spacing resolve the same way they do in the CLI
-and ESLint plugin. Point at a specific file instead via the `tailwind-a11y.configPath`
-setting:
+and ESLint plugin. Editing a `.js`/`.cjs`/`.css` config is picked up live, same as
+editing any other file — a `.mjs` config is the one exception: Node caches it in a
+way this extension can't invalidate, so an edit to a `.mjs` config needs a window
+reload (Developer: Reload Window) to take effect. Point at a specific file instead
+via the `tailwind-a11y.configPath` setting:
 
 ```json
 { "tailwind-a11y.configPath": "./app/globals.css" }

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.12.0"
+    "tailwind-a11y": "^0.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## What

Custom theme resolution only ever looked for `tailwind.config.js`/`.cjs`. Turns out `.mjs` support doesn't need the async refactor or transpiling dependency it was previously assumed to need -- Node 20.19+/22.13+ can `require()` an ESM module synchronously, no `import()` involved. `loadCustomTheme()` already treated `ERR_REQUIRE_ESM` as "no config found" for older Node, so this is a purely additive, backward-compatible change: on a Node that lacks the capability, a `.mjs` config just continues to fail to load exactly as it does today. Every adapter's actual runtime already clears the threshold -- the GitHub Action runs on Node 24, the ESLint plugin's own `engines.node` already excludes anything older, and the CLI's broad `>=18` floor degrades safely on the rest.

## Why `.ts` isn't part of this

Considered and declined, not a "not yet." Node's native TypeScript type-stripping only turns on when the *host* process is launched with `--experimental-strip-types` -- a library has no way to make that happen on the user's behalf, so the only real path to transparent `.ts` support would be promoting `esbuild` from a devDependency to a genuine runtime dependency, a real native-binary weight increase. Scaffolding a fresh `create-next-app --typescript --tailwind` this session showed current Tailwind v4 projects don't generate any JS/TS config file at all anymore -- theme customization moved to a CSS `@theme` block, which this engine already fully supports. `.ts` config support would only help a shrinking population of legacy v3-plus-TypeScript projects, not worth the dependency.

## A real, disclosed limitation

`require.cache` busting -- the mechanism that lets a long-lived process like the VS Code extension host pick up a config edit without restarting -- doesn't work for `.mjs`. Confirmed with a real edit-and-reload test: Node caches a synchronously-required ESM module in its own internal registry, separate from `require.cache`, so deleting the cache entry doesn't force a reload. CLI and GitHub Action are unaffected (fresh process every run); editing a `.mjs` config in VS Code needs a window reload to take effect. Documented plainly in the VS Code README and the engine's CLAUDE.md rather than left as a surprise.

## Versions

Engine, eslint-plugin, and the GitHub Action go 0.12.0 -> 0.13.0. VS Code goes 0.13.0 -> 0.14.0.

## Test plan

- [x] Full test suite passes across all four packages (405 tests)
- [x] End-to-end: a scratch project with only a `tailwind.config.mjs` defining a custom color, run through the built CLI -- the contrast check now fires against it where it would have silently been skipped before
- [x] GitHub Action bundle rebuilt and confirmed non-stale