### PR TITLE
Fix ring-offset-{color} being wrongly accepted as a real outline replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.13.1`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.13.2`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.13.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.13.1`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.1"
+        "tailwind-a11y": "^0.13.2"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.13.1"
+        "tailwind-a11y": "^0.13.2"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.1"
+        "tailwind-a11y": "^0.13.2"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.0"
+        "tailwind-a11y": "^0.13.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.13.0"
+        "tailwind-a11y": "^0.13.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.0"
+        "tailwind-a11y": "^0.13.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.13.1"
+    "tailwind-a11y": "^0.13.2"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.13.0"
+    "tailwind-a11y": "^0.13.1"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49175,16 +49175,17 @@ var NON_COLOR_SCALE_NAMES = /* @__PURE__ */ new Set(["opacity", "linear", "conic
 function lastColorToken(className, prefix) {
   let found = null;
   for (const raw of className.split(/\s+/).filter(Boolean)) {
-    const base = raw.slice(raw.lastIndexOf(":") + 1);
-    if (!base.startsWith(`${prefix}-`))
+    if (raw.includes(":"))
       continue;
-    const rest = base.slice(prefix.length + 1);
+    if (!raw.startsWith(`${prefix}-`))
+      continue;
+    const rest = raw.slice(prefix.length + 1);
     if (!COLOR_TOKEN.test(rest))
       continue;
     const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
     if (scaleName && NON_COLOR_SCALE_NAMES.has(scaleName))
       continue;
-    found = base;
+    found = raw;
   }
   return found;
 }
@@ -49933,14 +49934,13 @@ function checkFocusIndicators(checks) {
 var NON_TEXT_MIN_RATIO = 3;
 var FOCUS_INDICATOR_MIN_THICKNESS_PX = 2;
 var WIDTH_SCALE = { "0": 0, "1": 1, "2": 2, "4": 4, "8": 8 };
-function lastIndicatorColorToken(focusClasses) {
+function lastColorTokenForIndicator(focusClasses, prefix) {
   let found = null;
   for (const raw of focusClasses) {
     const base = raw.slice(raw.lastIndexOf(":") + 1);
-    const match = /^(?:outline|ring)-(.+)$/.exec(base);
-    if (!match)
+    if (!base.startsWith(`${prefix}-`))
       continue;
-    const rest = match[1];
+    const rest = base.slice(prefix.length + 1);
     if (!COLOR_TOKEN.test(rest))
       continue;
     const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
@@ -49950,14 +49950,13 @@ function lastIndicatorColorToken(focusClasses) {
   }
   return found;
 }
-function lastIndicatorThicknessPx(focusClasses) {
+function thicknessTokenForIndicator(focusClasses, prefix) {
   let found = null;
   for (const raw of focusClasses) {
     const base = raw.slice(raw.lastIndexOf(":") + 1);
-    const match = /^(?:outline|ring)-(.+)$/.exec(base);
-    if (!match)
+    if (!base.startsWith(`${prefix}-`))
       continue;
-    const token = match[1];
+    const token = base.slice(prefix.length + 1);
     if (token in WIDTH_SCALE) {
       found = WIDTH_SCALE[token];
       continue;
@@ -49973,26 +49972,34 @@ function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
   for (const check of checks) {
     if (!check.bgClass)
       continue;
-    const indicatorBase = lastIndicatorColorToken(check.focusClasses);
-    if (!indicatorBase)
-      continue;
-    const indicatorHex = resolveColorValue(indicatorBase, palette);
     const bgHex = resolveColorValue(check.bgClass, palette);
-    if (!indicatorHex || !bgHex)
+    const bgRgb = bgHex ? hexToRgb(bgHex) : null;
+    if (!bgRgb)
       continue;
-    const indicatorRgb = hexToRgb(indicatorHex);
-    const bgRgb = hexToRgb(bgHex);
-    if (!indicatorRgb || !bgRgb)
+    const candidates = [];
+    for (const prefix of ["outline", "ring"]) {
+      const indicatorBase = lastColorTokenForIndicator(check.focusClasses, prefix);
+      if (!indicatorBase)
+        continue;
+      const indicatorHex = resolveColorValue(indicatorBase, palette);
+      const indicatorRgb = indicatorHex ? hexToRgb(indicatorHex) : null;
+      if (!indicatorRgb)
+        continue;
+      const ratio = contrastRatio(indicatorRgb, bgRgb);
+      const contrastFails = ratio < NON_TEXT_MIN_RATIO;
+      let thicknessPx = null;
+      if (strict)
+        thicknessPx = thicknessTokenForIndicator(check.focusClasses, prefix);
+      const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
+      candidates.push({ indicatorBase, ratio, contrastFails, thicknessPx, thicknessFails });
+    }
+    if (candidates.length === 0)
       continue;
-    const ratio = contrastRatio(indicatorRgb, bgRgb);
-    const contrastFails = ratio < NON_TEXT_MIN_RATIO;
-    let thicknessPx = null;
-    if (strict)
-      thicknessPx = lastIndicatorThicknessPx(check.focusClasses);
-    const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
-    if (!contrastFails && !thicknessFails)
+    const allFail = candidates.every((c) => c.contrastFails || c.thicknessFails);
+    if (!allFail)
       continue;
-    const rawIndicatorClass = check.focusClasses.find((raw) => raw.slice(raw.lastIndexOf(":") + 1) === indicatorBase);
+    const worst = candidates.reduce((a, b) => b.ratio < a.ratio ? b : a);
+    const rawIndicatorClass = check.focusClasses.find((raw) => raw.slice(raw.lastIndexOf(":") + 1) === worst.indicatorBase);
     violations.push({
       type: "focus-contrast",
       file: check.file,
@@ -50000,10 +50007,10 @@ function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
       tagName: check.tagName,
       indicatorClass: rawIndicatorClass,
       bgClass: check.bgClass,
-      ratio,
+      ratio: worst.ratio,
       required: NON_TEXT_MIN_RATIO,
-      level: thicknessFails ? "AAA" : "AA",
-      ...thicknessFails && thicknessPx !== null ? { thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX } : {}
+      level: worst.thicknessFails ? "AAA" : "AA",
+      ...worst.thicknessFails && worst.thicknessPx !== null ? { thicknessPx: worst.thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX } : {}
     });
   }
   return violations;

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49899,6 +49899,10 @@ function isColorOnlyShadowOrRing(base) {
     return true;
   return false;
 }
+function isColorOnlyRingOffset(base) {
+  const match = /^ring-offset-(.+)$/.exec(base);
+  return !!match && COLOR_TOKEN.test(match[1]);
+}
 function baseUtility(raw) {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -49909,6 +49913,8 @@ function isReplacement(raw) {
   if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base))
     return false;
   if (isColorOnlyShadowOrRing(base))
+    return false;
+  if (isColorOnlyRingOffset(base))
     return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.1",
+    "tailwind-a11y": "^0.13.2",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.0",
+    "tailwind-a11y": "^0.13.1",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -429,15 +429,44 @@ systematic one-time audit walked the focus-indicator check's entire risk
 surface against a real Tailwind v4 build (see the "Focus indicator" bullet
 above) and found five more in one pass: `border-none`/`border-hidden`,
 `border-spacing-*`, and color-only `shadow-*`/`ring-*`. That audit also
-confirmed the *other* two checks in this file have no equivalent risk: the
-touch-target check resolves against a closed, enumerated lookup table
-(`spacingScale`) rather than a permissive regex, so there's no same-shape-
-different-meaning token possible there; the contrast check's `bg-*`
-namespace was re-walked against every real `bg-*` utility category and
-turned up nothing beyond what was already fixed (`opacity`/`linear`/
-`conic`). If a new regex/token-matching check is ever added, prefer this
-same approach — verify against the real tool's actual output, not memory —
-over waiting for bugs to surface one at a time.
+claimed the contrast check's `bg-*` namespace had been re-walked and turned
+up nothing beyond `opacity`/`linear`/`conic` — **this later turned out to be
+incomplete**: the audit only checked for same-shape *base utility names*
+that could mask a color, not the orthogonal case of a *variant-scoped*
+color masking the real resting-state one. `lastColorToken()` (and the
+near-duplicate `lastIndicatorColorToken` this used to be, now
+`lastColorTokenForIndicator`) stripped `hover:`/`dark:`/`md:`/etc. prefixes
+*before* last-token-wins, so `bg-white dark:bg-gray-900` on an element with
+`text-gray-300` silently reported nothing at all — `dark:bg-gray-900` won
+last-token-wins purely by being written later, `gray-300`-on-`gray-900`
+happens to pass, and the real 1.47:1 `gray-300`-on-`bg-white` resting-state
+failure was never even attempted. Independent adversarial testing found
+this (not the original audit). Fixed the same way `extractTouchTargets.ts`'s
+`lastSizeToken` already handled it (`if (raw.includes(":")) continue;` —
+skip a variant-scoped token entirely, don't let it participate in
+resting-state resolution at all) — a guard `lastColorToken` never had.
+
+A second, related bug found the same way: `checkFocusContrast` used to race
+`outline-*` against `ring-*` in one shared last-token-wins slot, even though
+both are independent CSS mechanisms (outline-color/-width vs. box-shadow)
+that render *simultaneously* regardless of which is written first (verified
+against a real v4 build) — so an element with a passing `outline-*` and a
+failing `ring-*` got a verdict that flipped purely based on class order.
+Fixed by evaluating each present indicator independently and only flagging
+when *all* present indicators fail (a user only needs one sufficiently
+visible indicator to perceive the focus state) — see
+`lastColorTokenForIndicator`/`thicknessTokenForIndicator` in
+`checkFocusIndicator.ts`.
+
+Lesson for future audits: "does a same-shape token mask a real one" isn't
+just about base-utility-name decoys — variant scope and cross-mechanism
+racing are two more axes of the same last-token-wins risk, and a one-time
+audit checking only the first axis will still miss the other two. If a new
+regex/token-matching check is ever added, prefer verifying against the real
+tool's actual output, not memory, over waiting for bugs to surface one at a
+time — but also explicitly check all three axes (decoy names, variant
+scope, cross-mechanism racing), not just whichever one motivated the
+original audit.
 
 ## Stack
 

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -200,7 +200,14 @@ Tailwind-class-level sizing or focus-style analysis).
     `shadow-{color}`/`ring-{color}` alone, e.g. `shadow-red-500` (only sets
     the `--tw-shadow-color`/`--tw-ring-color` CSS variable — the actual
     `box-shadow` comes from a separate *size* utility like `shadow-lg`/
-    `ring-2` that references it, so the color alone renders nothing).
+    `ring-2` that references it, so the color alone renders nothing);
+    `ring-offset-{color}` alone, e.g. `ring-offset-blue-500` (one level
+    deeper than plain `ring-{color}` — sets only `--tw-ring-offset-color`,
+    same "no box-shadow without a real ring width" mechanism — missed by
+    the original one-time audit and only found later via independent
+    adversarial testing, since `isColorOnlyShadowOrRing`'s `ring-(.+)`
+    match doesn't recurse into the `offset-` sub-shape; needed its own
+    `isColorOnlyRingOffset` check).
     Confirmed *not* decoys, deliberately left alone: `outline-dashed`/
     `-dotted`/`-solid`/`-double` alone (unlike border-width, preflight does
     not reset `outline-width`, so the browser's default ~3px applies and

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractClasses.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.test.ts
@@ -106,4 +106,29 @@ describe("extractChecks", () => {
       ]);
     }
   );
+
+  // Caught in independent review: a variant-scoped background utility
+  // (dark:/hover:/etc.) written after the real resting-state one used to
+  // win last-token-wins, masking a real violation entirely (the resting-
+  // state bg-white vs the failing text color was never checked at all,
+  // since dark:bg-gray-900 -- which text-gray-300 happens to pass against
+  // -- was treated as the background instead).
+  it.each(["dark:bg-gray-900", "hover:bg-gray-900", "md:bg-gray-900"])(
+    "does not let a variant-scoped background %s override the real resting-state background (regression)",
+    (variantScoped) => {
+      const code = `const C = () => <div className="bg-white ${variantScoped}"><p className="text-gray-300">x</p></div>;`;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toEqual([
+        { file: "fake.tsx", line: 1, textColorClass: "text-gray-300", bgColorClass: "bg-white", bgSource: "parent" },
+      ]);
+    }
+  );
+
+  it("does not let a variant-scoped text color override the real resting-state text color (regression)", () => {
+    const code = `const C = () => <p className="text-gray-300 dark:text-white bg-white">x</p>;`;
+    const checks = extractChecks(code, "fake.tsx");
+    expect(checks).toEqual([
+      { file: "fake.tsx", line: 1, textColorClass: "text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+  });
 });

--- a/packages/tailwind-a11y/src/parser/extractClasses.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.ts
@@ -38,13 +38,24 @@ const NON_COLOR_SCALE_NAMES = new Set(["opacity", "linear", "conic"]);
 export function lastColorToken(className: string, prefix: "text" | "bg"): string | null {
   let found: string | null = null;
   for (const raw of className.split(/\s+/).filter(Boolean)) {
-    const base = raw.slice(raw.lastIndexOf(":") + 1); // strip hover:/dark:/md: variants
-    if (!base.startsWith(`${prefix}-`)) continue;
-    const rest = base.slice(prefix.length + 1);
+    // Variant-scoped classes (hover:/dark:/md:/...) are skipped entirely,
+    // not stripped down to their base utility -- fixed after independent
+    // testing found a real false negative: `bg-white dark:bg-gray-900`
+    // with `text-gray-300` silently passed, because stripping the `dark:`
+    // prefix let it participate in last-token-wins as if it were the real,
+    // always-rendered resting-state background, when `dark:bg-gray-900`
+    // only ever applies under a completely different condition. Mirrors
+    // `extractTouchTargets.ts`'s `lastSizeToken`, which already excludes
+    // any variant-scoped size token from resting-state resolution the same
+    // way (`if (raw.includes(":")) continue;`) -- this had no equivalent
+    // guard for colors.
+    if (raw.includes(":")) continue;
+    if (!raw.startsWith(`${prefix}-`)) continue;
+    const rest = raw.slice(prefix.length + 1);
     if (!COLOR_TOKEN.test(rest)) continue;
     const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
     if (scaleName && NON_COLOR_SCALE_NAMES.has(scaleName)) continue;
-    found = base;
+    found = raw;
   }
   return found;
 }

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
@@ -137,6 +137,47 @@ describe("checkFocusIndicators", () => {
     expect(violations).toHaveLength(1);
   });
 
+  // Caught in independent adversarial testing: ring-offset-{color} only
+  // sets the --tw-ring-offset-color CSS variable and never draws anything
+  // on its own (verified against a real Tailwind v4 build) -- it fell
+  // through the color-only-shadow/ring check above (that one only matches
+  // bare ring-{color}, not the one-level-deeper ring-offset-{color} shape)
+  // and was wrongly accepted as a real replacement via the generic ring-*
+  // prefix match.
+  it.each(["focus:ring-offset-blue-500", "focus:ring-offset-red-500/50", "focus:ring-offset-[#fff]"])(
+    "still flags when the only 'replacement' is a color-only ring-offset decoy %s (regression)",
+    (decoy) => {
+      const violations = checkFocusIndicators([
+        { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", decoy] },
+      ]);
+      expect(violations).toHaveLength(1);
+    }
+  );
+
+  it("still flags when ring-offset-4 (width) and ring-offset-blue-500 (color) are combined with no real ring width", () => {
+    const violations = checkFocusIndicators([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-offset-4", "focus:ring-offset-blue-500"],
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("passes when ring-offset-{color} is paired with a real ring width", () => {
+    const violations = checkFocusIndicators([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-offset-4", "focus:ring-offset-blue-500"],
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
   it("still passes when a shadow/ring color is paired with a real size utility", () => {
     const violations = checkFocusIndicators([
       { file: "f.tsx", line: 1, tagName: "button", focusClasses: ["focus:outline-none", "focus:shadow-lg", "focus:shadow-red-500"] },

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.test.ts
@@ -353,21 +353,66 @@ describe("checkFocusContrast", () => {
     expect(violations).toEqual([]);
   });
 
-  it("last-token-wins across outline-* and ring-* together, not per-prefix", () => {
+  // outline-* and ring-* are evaluated as independent candidates (fixed
+  // after independent review found a real bug: an earlier version raced
+  // them against each other in one shared last-token-wins slot, so the
+  // verdict depended purely on which was written later, even though both
+  // render simultaneously regardless of order -- verified against a real
+  // Tailwind v4 build). A passing outline-* and a failing ring-* together
+  // still pass overall: a user only needs one sufficiently visible
+  // indicator to perceive the focus state.
+  it("passes when at least one of two present indicators (outline-* and ring-*) has sufficient contrast", () => {
     const violations = checkFocusContrast([
       {
         file: "f.tsx",
         line: 1,
         tagName: "button",
-        // outline-blue-400 (low contrast) written first, ring-white (high
-        // contrast) written after -- the later one in source order is what
-        // actually renders, so it should win over the ignored one.
         focusClasses: ["focus:outline-none", "focus:outline-blue-400", "focus:ring-2", "focus:ring-white"],
         bgClass: "bg-blue-500",
         bgSource: "self",
       },
     ]);
     expect(violations).toEqual([]);
+  });
+
+  it("gives the identical verdict regardless of which of outline-*/ring-* is written last", () => {
+    const swapped = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        // Same two indicators as the test above, written in the opposite
+        // order -- must produce the same passing verdict.
+        focusClasses: ["focus:outline-none", "focus:ring-2", "focus:ring-white", "focus:outline-blue-400"],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(swapped).toEqual([]);
+  });
+
+  it("flags a violation, naming the worse offender, when both present indicators fail", () => {
+    const violations = checkFocusContrast([
+      {
+        file: "f.tsx",
+        line: 1,
+        tagName: "button",
+        // Both fail against blue-500, but outline-blue-400 (ratio ~1.45) is
+        // the worse of the two -- ring-blue-300 (ratio ~2.04) is closer to
+        // passing, even though it's still under the 3:1 minimum.
+        focusClasses: [
+          "focus:outline-none",
+          "focus:outline-2",
+          "focus:outline-blue-400",
+          "focus:ring-2",
+          "focus:ring-blue-300",
+        ],
+        bgClass: "bg-blue-500",
+        bgSource: "self",
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].indicatorClass).toBe("focus:outline-blue-400");
   });
 
   it("composes end-to-end with extractFocusIndicatorChecks", () => {

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
@@ -169,22 +169,29 @@ const FOCUS_INDICATOR_MIN_THICKNESS_PX = 2;
 // paired with an explicit color utility) but never a thickness value.
 const WIDTH_SCALE: Record<string, number> = { "0": 0, "1": 1, "2": 2, "4": 4, "8": 8 };
 
-// Near-duplicate of extractClasses.ts's lastColorToken, not a call to it:
-// that function takes a single prefix ("text" | "bg") and this needs
-// last-token-wins across *two* prefixes (outline-*, ring-*) in one pass, so
-// whichever was actually written last in the class list wins regardless of
-// which utility it is. Reuses COLOR_TOKEN (the one shared "is this
-// color-shaped" test) and only excludes the "opacity" scale name locally --
-// lastColorToken's full NON_COLOR_SCALE_NAMES set also excludes
-// "linear"/"conic", but those are bg-gradient-angle utilities with no
-// outline-*/ring-* equivalent, so they can never appear here.
-function lastIndicatorColorToken(focusClasses: string[]): string | null {
+// Last-token-wins WITHIN one prefix only. Fixed after independent testing
+// found a real bug: the original version raced outline-* against ring-*
+// in one shared last-token-wins slot, so an element with BOTH a passing
+// outline-* and a failing ring-* (or vice versa) got a verdict that
+// depended purely on which was written later in the class string -- even
+// though outline-*/ring-* are two independent CSS mechanisms
+// (outline-color/-width vs. box-shadow) that both render simultaneously
+// regardless of order (verified against a real Tailwind v4 build).
+// Last-token-wins is still correct *within* a single prefix (e.g.
+// `outline-red-500 outline-blue-600` really does render as blue-600, the
+// later declaration winning in CSS) -- only racing the two prefixes
+// against each other was wrong. Reuses COLOR_TOKEN (the shared
+// "is this color-shaped" test) and only excludes the "opacity" scale name
+// locally -- extractClasses.ts's lastColorToken's full NON_COLOR_SCALE_NAMES
+// set also excludes "linear"/"conic", but those are bg-gradient-angle
+// utilities with no outline-*/ring-* equivalent, so they can never appear
+// here.
+function lastColorTokenForIndicator(focusClasses: string[], prefix: "outline" | "ring"): string | null {
   let found: string | null = null;
   for (const raw of focusClasses) {
     const base = raw.slice(raw.lastIndexOf(":") + 1);
-    const match = /^(?:outline|ring)-(.+)$/.exec(base);
-    if (!match) continue;
-    const rest = match[1];
+    if (!base.startsWith(`${prefix}-`)) continue;
+    const rest = base.slice(prefix.length + 1);
     if (!COLOR_TOKEN.test(rest)) continue;
     const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
     if (scaleName === "opacity") continue;
@@ -193,18 +200,17 @@ function lastIndicatorColorToken(focusClasses: string[]): string | null {
   return found;
 }
 
-// Same last-token-wins-across-both-prefixes shape as above, but for width:
-// only an enumerated outline-{N}/ring-{N} or an arbitrary [Npx] sets a
-// thickness. A color token (ring-blue-400), ring-offset-*, ring-inset, etc.
-// don't match either shape and are silently ignored here -- they're a
-// different utility's job (color, offset, inset), not this one's.
-function lastIndicatorThicknessPx(focusClasses: string[]): number | null {
+// Same per-prefix last-token-wins shape as above, but for width: only an
+// enumerated outline-{N}/ring-{N} or an arbitrary [Npx] sets a thickness.
+// A color token (ring-blue-400), ring-offset-*, ring-inset, etc. don't
+// match either shape and are silently ignored here -- they're a different
+// utility's job (color, offset, inset), not this one's.
+function thicknessTokenForIndicator(focusClasses: string[], prefix: "outline" | "ring"): number | null {
   let found: number | null = null;
   for (const raw of focusClasses) {
     const base = raw.slice(raw.lastIndexOf(":") + 1);
-    const match = /^(?:outline|ring)-(.+)$/.exec(base);
-    if (!match) continue;
-    const token = match[1];
+    if (!base.startsWith(`${prefix}-`)) continue;
+    const token = base.slice(prefix.length + 1);
     if (token in WIDTH_SCALE) {
       found = WIDTH_SCALE[token];
       continue;
@@ -222,31 +228,59 @@ export function checkFocusContrast(
 ): FocusContrastViolation[] {
   const violations: FocusContrastViolation[] = [];
 
+  interface Candidate {
+    indicatorBase: string;
+    ratio: number;
+    contrastFails: boolean;
+    thicknessPx: number | null;
+    thicknessFails: boolean;
+  }
+
   for (const check of checks) {
     if (!check.bgClass) continue; // no resolvable background — skip, not a guess
 
-    const indicatorBase = lastIndicatorColorToken(check.focusClasses);
-    if (!indicatorBase) continue; // no explicit outline-*/ring-* color — out of scope, see CLAUDE.md
-
-    const indicatorHex = resolveColorValue(indicatorBase, palette);
     const bgHex = resolveColorValue(check.bgClass, palette);
-    if (!indicatorHex || !bgHex) continue; // custom theme color / unsupported arbitrary value — skip
+    const bgRgb = bgHex ? hexToRgb(bgHex) : null;
+    if (!bgRgb) continue; // custom theme color / unsupported arbitrary value — skip
 
-    const indicatorRgb = hexToRgb(indicatorHex);
-    const bgRgb = hexToRgb(bgHex);
-    if (!indicatorRgb || !bgRgb) continue;
+    // outline-* and ring-* are evaluated as independent candidates, not
+    // raced against each other -- both are real, simultaneously-rendering
+    // mechanisms (see lastColorTokenForIndicator's comment for why), so an
+    // element can have zero, one, or both present at once.
+    const candidates: Candidate[] = [];
+    for (const prefix of ["outline", "ring"] as const) {
+      const indicatorBase = lastColorTokenForIndicator(check.focusClasses, prefix);
+      if (!indicatorBase) continue; // this mechanism isn't in use on this element
 
-    const ratio = contrastRatio(indicatorRgb, bgRgb);
-    const contrastFails = ratio < NON_TEXT_MIN_RATIO;
+      const indicatorHex = resolveColorValue(indicatorBase, palette);
+      const indicatorRgb = indicatorHex ? hexToRgb(indicatorHex) : null;
+      if (!indicatorRgb) continue; // custom theme color / unsupported arbitrary value — skip this candidate
 
-    let thicknessPx: number | null = null;
-    if (strict) thicknessPx = lastIndicatorThicknessPx(check.focusClasses);
-    const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
+      const ratio = contrastRatio(indicatorRgb, bgRgb);
+      const contrastFails = ratio < NON_TEXT_MIN_RATIO;
 
-    if (!contrastFails && !thicknessFails) continue;
+      let thicknessPx: number | null = null;
+      if (strict) thicknessPx = thicknessTokenForIndicator(check.focusClasses, prefix);
+      const thicknessFails = strict && thicknessPx !== null && thicknessPx < FOCUS_INDICATOR_MIN_THICKNESS_PX;
+
+      candidates.push({ indicatorBase, ratio, contrastFails, thicknessPx, thicknessFails });
+    }
+
+    if (candidates.length === 0) continue; // no resolvable outline-*/ring-* color at all
+
+    // A user only needs ONE sufficiently visible (and, under strict,
+    // sufficiently thick) focus indicator to perceive the focus state --
+    // if any present candidate fully passes, this element is compliant
+    // even if another present indicator independently would have failed.
+    const allFail = candidates.every((c) => c.contrastFails || c.thicknessFails);
+    if (!allFail) continue;
+
+    // More than one candidate present and both fail -- report the worst
+    // (lowest-ratio) offender.
+    const worst = candidates.reduce((a, b) => (b.ratio < a.ratio ? b : a));
 
     const rawIndicatorClass = check.focusClasses.find(
-      (raw) => raw.slice(raw.lastIndexOf(":") + 1) === indicatorBase
+      (raw) => raw.slice(raw.lastIndexOf(":") + 1) === worst.indicatorBase
     )!;
 
     violations.push({
@@ -256,11 +290,11 @@ export function checkFocusContrast(
       tagName: check.tagName,
       indicatorClass: rawIndicatorClass,
       bgClass: check.bgClass,
-      ratio,
+      ratio: worst.ratio,
       required: NON_TEXT_MIN_RATIO,
-      level: thicknessFails ? "AAA" : "AA",
-      ...(thicknessFails && thicknessPx !== null
-        ? { thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX }
+      level: worst.thicknessFails ? "AAA" : "AA",
+      ...(worst.thicknessFails && worst.thicknessPx !== null
+        ? { thicknessPx: worst.thicknessPx, requiredThicknessPx: FOCUS_INDICATOR_MIN_THICKNESS_PX }
         : {}),
     });
   }

--- a/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
+++ b/packages/tailwind-a11y/src/rules/checkFocusIndicator.ts
@@ -83,6 +83,22 @@ function isColorOnlyShadowOrRing(base: string): boolean {
   return false;
 }
 
+// ring-offset-{color} (e.g. ring-offset-blue-500) sets only the
+// --tw-ring-offset-color CSS variable -- the offset ring itself is only
+// ever drawn when a real ring width is *also* present (ring-2, etc.),
+// verified against a real Tailwind v4 build. MODIFIER_ONLY above already
+// excludes the numeric width form (ring-offset-4), but its regex requires
+// digits after "offset-", so it never matched this color-shaped form --
+// caught in independent adversarial testing (a real false negative: this
+// fell through to the generic ring-* prefix match at the bottom of
+// isReplacement and was silently accepted as a real replacement). One
+// level deeper than isColorOnlyShadowOrRing above, so a separate check
+// rather than folding into it.
+function isColorOnlyRingOffset(base: string): boolean {
+  const match = /^ring-offset-(.+)$/.exec(base);
+  return !!match && COLOR_TOKEN.test(match[1]);
+}
+
 function baseUtility(raw: string): string {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -92,6 +108,7 @@ function isReplacement(raw: string): boolean {
   if (DEGENERATE_BASES.has(base) || MODIFIER_ONLY.test(base)) return false;
   if (NON_VISUAL_BASES.has(base) || NON_VISUAL_PATTERN.test(base)) return false;
   if (isColorOnlyShadowOrRing(base)) return false;
+  if (isColorOnlyRingOffset(base)) return false;
   return /^(ring|border|shadow|bg|outline)(-|$)/.test(base);
 }
 

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.1"
+    "tailwind-a11y": "^0.13.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.0"
+    "tailwind-a11y": "^0.13.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## What

`ring-offset-{color}` (e.g. `ring-offset-blue-500`) only sets the `--tw-ring-offset-color` CSS variable -- verified against a real Tailwind v4 build that it never draws anything without a real ring width also present (`ring-2`, etc.), the same mechanism as the already-excluded bare `ring-{color}` case. But `isColorOnlyShadowOrRing`'s regex only matches `ring-{color}` directly and doesn't recurse into the `offset-` sub-shape, and `MODIFIER_ONLY`'s `ring-offset` exclusion only matches the numeric width form (`ring-offset-4`), not the color form -- so `ring-offset-{color}` fell through to the generic `ring-*` prefix match at the bottom of `isReplacement()` and was silently accepted as a real, visible replacement for a removed outline.

Fixes #22.

## Versions

Engine, eslint-plugin, and the GitHub Action go 0.13.1 -> 0.13.2. VS Code goes 0.14.1 -> 0.14.2.

## Test plan

- [x] Full test suite passes across all four packages (416 tests), including regression coverage for the exact reported case and the paired-with-a-real-ring-width case
- [x] Re-ran the original issue repro directly against the built CLI -- now correctly flagged
- [x] GitHub Action bundle rebuilt and confirmed non-stale