### PR TITLE
Detect interaction-scoped animate-* motion: WCAG 2.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.13.5",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.5"
+        "tailwind-a11y": "^0.14.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.13.5",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.13.5"
+        "tailwind-a11y": "^0.14.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.13.5",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.14.5",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.13.5"
+        "tailwind-a11y": "^0.14.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -46,7 +46,7 @@ export default [
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |
-| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
+| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.13.5"
+    "tailwind-a11y": "^0.14.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.test.ts
@@ -36,6 +36,21 @@ ruleTester.run("reduced-motion", rule, {
       filename: "Identity.jsx",
       code: `export const D = () => <div className="transition-transform hover:scale-100">x</div>;`,
     },
+    {
+      name: "a bare motion-reduce:animate-none guard passes for the animate mechanism",
+      filename: "OkAnimate.jsx",
+      code: `export const Ok = () => <div className="hover:animate-bounce motion-reduce:animate-none">x</div>;`,
+    },
+    {
+      name: "hover:animate-pulse is opacity-only, not real motion",
+      filename: "Pulse.jsx",
+      code: `export const D = () => <div className="hover:animate-pulse">x</div>;`,
+    },
+    {
+      name: "an unscoped animate-bounce with no interaction variant is 2.2.2 territory, out of scope here",
+      filename: "Unscoped.jsx",
+      code: `export const D = () => <div className="animate-bounce">x</div>;`,
+    },
   ],
   invalid: [
     {
@@ -46,6 +61,19 @@ ruleTester.run("reduced-motion", rule, {
         {
           message:
             "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      name: "an interaction-scoped animate-bounce with no transition base at all fires under the animate mechanism",
+      filename: "Bounce.jsx",
+      code: `export const Bounce = () => <div className="hover:animate-bounce">x</div>;`,
+      errors: [
+        {
+          message:
+            "<div> animates hover:animate-bounce via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
           line: 1,
           column: 1,
         },

--- a/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
+++ b/packages/eslint-plugin-tailwind-a11y/src/rules/reduced-motion.ts
@@ -6,7 +6,7 @@ const rule: Rule.RuleModule = {
     type: "problem",
     docs: {
       description:
-        "Enforce WCAG 2.3.3 AAA -- interaction-triggered transform animation (scale/rotate/translate/skew under hover:/focus:/active:) must be disableable via prefers-reduced-motion",
+        "Enforce WCAG 2.3.3 AAA -- interaction-triggered transform animation (scale/rotate/translate/skew under hover:/focus:/active:) or animate-spin/-ping/-bounce under the same variants must be disableable via prefers-reduced-motion",
       recommended: true,
       url: "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#reduced-motion",
     },
@@ -20,9 +20,15 @@ const rule: Rule.RuleModule = {
     // here, enabling this rule at all is already that opt-in gesture, so
     // this is the one caller that always passes `true`.
     schema: [],
+    // Two messageIds, not one with a conditional {{placeholder}} -- ESLint's
+    // mustache-style templates can't branch on data, and the animate
+    // mechanism has no transitionClass to interpolate at all (see
+    // ReducedMotionViolation's discriminated union in the engine).
     messages: {
-      reducedMotion:
+      reducedMotionTransition:
         "<{{tagName}}> animates {{motionClass}} via {{transitionClass}} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
+      reducedMotionAnimate:
+        "<{{tagName}}> animates {{motionClass}} via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable",
     },
   },
 
@@ -35,11 +41,19 @@ const rule: Rule.RuleModule = {
         );
 
         for (const v of violations) {
-          context.report({
-            loc: { line: v.line, column: 0 },
-            messageId: "reducedMotion",
-            data: { tagName: v.tagName, motionClass: v.motionClass, transitionClass: v.transitionClass },
-          });
+          if (v.mechanism === "animate") {
+            context.report({
+              loc: { line: v.line, column: 0 },
+              messageId: "reducedMotionAnimate",
+              data: { tagName: v.tagName, motionClass: v.motionClass },
+            });
+          } else {
+            context.report({
+              loc: { line: v.line, column: 0 },
+              messageId: "reducedMotionTransition",
+              data: { tagName: v.tagName, motionClass: v.motionClass, transitionClass: v.transitionClass },
+            });
+          }
         }
       },
     };

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -50034,6 +50034,9 @@ function baseUtility2(raw) {
 function variantSegments(raw) {
   return raw.split(":").slice(0, -1);
 }
+function isAnimateBase(base) {
+  return base.startsWith("animate-");
+}
 function extractReducedMotionChecks(code, filePath) {
   const ast = parseJSX(code, filePath);
   if (!ast)
@@ -50048,7 +50051,11 @@ function extractReducedMotionChecks(code, filePath) {
       const classes = className.split(/\s+/).filter(Boolean);
       const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility2(raw)));
       const hasInteractionClass = classes.some((raw) => variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v)));
-      if (!hasTransitionBase || !hasInteractionClass)
+      const hasInteractionScopedAnimate = classes.some((raw) => {
+        const base = baseUtility2(raw);
+        return isAnimateBase(base) && variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v));
+      });
+      if ((!hasTransitionBase || !hasInteractionClass) && !hasInteractionScopedAnimate)
         return;
       checks.push({
         file: filePath,
@@ -50089,6 +50096,7 @@ function isNonIdentityMotionUtility(base) {
     return Number(skew[2]) !== 0;
   return false;
 }
+var ANIMATE_MOTION_BASES = /* @__PURE__ */ new Set(["animate-spin", "animate-ping", "animate-bounce"]);
 function checkReducedMotion(checks, strict = false) {
   if (!strict)
     return [];
@@ -50107,6 +50115,29 @@ function checkReducedMotion(checks, strict = false) {
         hasMotionReduceGuard = true;
       }
     }
+    const hasMotionReduceAnimateGuard = check.classes.some((raw) => {
+      const segments = variantSegments2(raw);
+      return segments.length === 1 && segments[0] === "motion-reduce" && baseUtility3(raw) === "animate-none";
+    });
+    const animateMotionClass = check.classes.find((raw) => {
+      const segments = variantSegments2(raw);
+      if (segments.includes("motion-safe"))
+        return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS2.has(v)))
+        return false;
+      return ANIMATE_MOTION_BASES.has(baseUtility3(raw));
+    });
+    if (animateMotionClass && !hasMotionReduceAnimateGuard) {
+      violations.push({
+        type: "reduced-motion",
+        mechanism: "animate",
+        file: check.file,
+        line: check.line,
+        tagName: check.tagName,
+        motionClass: animateMotionClass,
+        level: "AAA"
+      });
+    }
     if (!realTransition)
       continue;
     if (hasMotionReduceGuard)
@@ -50123,6 +50154,7 @@ function checkReducedMotion(checks, strict = false) {
       continue;
     violations.push({
       type: "reduced-motion",
+      mechanism: "transition",
       file: check.file,
       line: check.line,
       tagName: check.tagName,
@@ -50445,7 +50477,7 @@ function formatViolation(v) {
       return v.thicknessPx !== void 0 ? `${base}; also only ${v.thicknessPx}px thick, needs >= ${v.requiredThicknessPx}px` : base;
     }
     case "reduced-motion":
-      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard \u2014 WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
+      return v.mechanism === "animate" ? `<${v.tagName}> animates ${v.motionClass} via a CSS animation with no motion-reduce:animate-none guard \u2014 WCAG 2.3.3 requires motion animation triggered by interaction to be disableable` : `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard \u2014 WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 function toAnnotationCommand(v) {

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.5",
+    "tailwind-a11y": "^0.14.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/github-action-tailwind-a11y/src/annotations.test.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.test.ts
@@ -111,9 +111,10 @@ describe("formatViolation", () => {
     );
   });
 
-  it("formats a reduced-motion violation", () => {
+  it("formats a reduced-motion violation (transition mechanism)", () => {
     const message = formatViolation({
       type: "reduced-motion",
+      mechanism: "transition",
       file: "src/Card.tsx",
       line: 3,
       tagName: "div",
@@ -123,6 +124,21 @@ describe("formatViolation", () => {
     });
     expect(message).toBe(
       "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
+
+  it("formats a reduced-motion violation (animate mechanism)", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      mechanism: "animate",
+      file: "src/Card.tsx",
+      line: 3,
+      tagName: "div",
+      motionClass: "hover:animate-bounce",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:animate-bounce via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
     );
   });
 });

--- a/packages/github-action-tailwind-a11y/src/annotations.ts
+++ b/packages/github-action-tailwind-a11y/src/annotations.ts
@@ -54,7 +54,9 @@ export function formatViolation(v: AnyViolation): string {
         : base;
     }
     case "reduced-motion":
-      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
+      return v.mechanism === "animate"
+        ? `<${v.tagName}> animates ${v.motionClass} via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`
+        : `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -290,26 +290,45 @@ Tailwind-class-level sizing or focus-style analysis).
   all.** Verified against the W3C Understanding doc that "motion animation"
   specifically means a change to an element's perceived size, shape, or
   position — color/opacity/blur changes don't qualify, even though they're
-  visually "animated" in the everyday sense. This is why `animate-spin`/
-  `-ping`/`-pulse`/`-bounce` are deliberately **not** covered here: they're
-  continuous, not interaction-triggered, so they belong under 2.2.2 (Pause,
-  Stop, Hide) instead, which has a materially different, harder-to-
-  statically-verify requirement (a 5-second-or-longer duration threshold
-  this tool has no way to know) — folding them in here would misattribute
-  the wrong SC. **Known gap, not yet closed**: that reasoning only holds for
-  an *unscoped* `animate-*` (always running). An interaction-scoped one
-  (`hover:animate-bounce` — a translateY-based, genuinely position-changing
-  animation per the Understanding doc's own definition, triggered only by
-  hover) is squarely 2.3.3's territory per the doc's own "not in response to
-  an intentional user activation" distinction for 2.2.2 — caught in
-  independent review, not yet implemented. The extractor's candidacy gate
-  requires a `transition`/`transition-all`/`transition-transform` base,
-  which `animate-*` isn't, so `hover:animate-bounce` alone currently
-  produces zero checks in any mode, not by deliberate design for this
-  specific case. Would need its own detection path (`animate-*` utilities
-  don't need a `transition-*` base to animate — they carry their own
-  `animation` property), not an extension of the transition-based logic
-  here.
+  visually "animated" in the everyday sense. This is why an **unscoped**
+  `animate-spin`/`-ping`/`-pulse`/`-bounce` is still not covered: continuous,
+  not interaction-triggered, so it belongs under 2.2.2 (Pause, Stop, Hide)
+  instead, which has a materially different, harder-to-statically-verify
+  requirement (a 5-second-or-longer duration threshold this tool has no way
+  to know) — folding it in here would misattribute the wrong SC.
+  **Interaction-scoped `animate-*` (`hover:animate-bounce`) is a second,
+  independent detection path under this same check, closing what was
+  previously a documented gap.** `animate-*` utilities carry their own
+  `animation` property and need no `transition-*` base at all, so
+  `checkReducedMotion` runs a fully separate block per check — computed
+  *before* the transition path's `continue` statements, not appended after
+  them, since an element with only `hover:animate-bounce` never sets
+  `realTransition` and would otherwise be skipped past entirely — that can
+  independently push its own violation, meaning one element can produce up
+  to two violations (one per mechanism) if both are genuinely present.
+  `ANIMATE_MOTION_BASES = new Set(["animate-spin", "animate-ping",
+  "animate-bounce"])`, verified against real Tailwind v4 compiled keyframes:
+  spin → `rotate(360deg)` (shape/orientation), ping → `scale(2)` +
+  `opacity:0` (includes a size change, so it qualifies same as any other
+  scale change regardless of the accompanying opacity fade), bounce →
+  `translateY(-25%)` (position) — `animate-pulse` (opacity-only) and
+  `animate-none` (the off/identity value) are excluded, same treatment as
+  `scale-100`/`rotate-0` on the transition side. The guard is a separate
+  `hasMotionReduceAnimateGuard` (bare, single-segment
+  `motion-reduce:animate-none` only) — kept independent from the transition
+  side's `hasMotionReduceGuard` so one mechanism's guard can't wrongly
+  suppress the other's violation. The extractor's candidacy gate
+  (`extractReducedMotion.ts`) adds this as a **single-class** OR condition —
+  one class must be both an `animate-` base and interaction-scoped in its own
+  variant stack — not two independent whole-element flags the way
+  `hasTransitionBase`/`hasInteractionClass` work for the transition path.
+  That distinction matters: `transition-transform` is never itself
+  interaction-scoped (paired with a separate `hover:scale-110`), but an
+  `animate-*` class is simultaneously its own trigger and its own animator,
+  so two independent flags would wrongly treat `animate-spin
+  hover:text-red-500` (an unscoped, continuously-running animation next to
+  an unrelated hover class) as a candidate — exactly the 2.2.2-not-2.3.3 case
+  above.
   - Because there's no AA tier, this is gated behind `strict` in every
     scan-everything-by-default adapter (CLI, VS Code, GitHub Action) — an
     AAA-only check running unconditionally would silently start failing

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -57,7 +57,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |
-| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
+| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
 
 ## Scope
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/cli.ts
+++ b/packages/tailwind-a11y/src/cli.ts
@@ -56,7 +56,9 @@ function formatViolation(v: AnyViolation): string {
         : base;
     }
     case "reduced-motion":
-      return `${v.line}: <${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
+      return v.mechanism === "animate"
+        ? `${v.line}: <${v.tagName}> animates ${v.motionClass} via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`
+        : `${v.line}: <${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }
 

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
@@ -58,4 +58,42 @@ describe("extractReducedMotionChecks", () => {
     expect(() => extractReducedMotionChecks(code, "fake.tsx")).not.toThrow();
     expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
   });
+
+  it.each(["hover:animate-bounce", "hover:animate-spin", "hover:animate-ping"])(
+    "collects an element with an interaction-scoped animate-* class alone, no transition base at all: %s",
+    (animateClass) => {
+      const code = `const C = () => <div className="${animateClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([
+        { file: "fake.tsx", line: 1, tagName: "div", classes: [animateClass] },
+      ]);
+    }
+  );
+
+  it("skips an unscoped animate-* class with no interaction variant anywhere on the element", () => {
+    const code = `const C = () => <div className="animate-bounce">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  // The extractor-level pitfall this design deliberately avoids: an unscoped,
+  // continuously-running animate-* sitting next to an unrelated hover class
+  // on the same element must NOT become a candidate just because both
+  // conditions are present somewhere on the element -- the animate-* class
+  // itself must be the one that's interaction-scoped.
+  it("skips an unscoped animate-* alongside an unrelated interaction-scoped class on the same element", () => {
+    const code = `const C = () => <div className="animate-bounce hover:text-red-500">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it.each(["motion-safe:hover:animate-bounce", "hover:motion-safe:animate-bounce"])(
+    "still collects when the interaction-scoped animate-* is itself motion-safe:-guarded, in either variant order: %s (rule decides pass/fail)",
+    (stackedClass) => {
+      const code = `const C = () => <div className="${stackedClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+    }
+  );
+
+  it("still collects an interaction-scoped animate-pulse -- extractor doesn't pre-filter which animate-* names are real motion, the rule does", () => {
+    const code = `const C = () => <div className="hover:animate-pulse">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
 });

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
@@ -34,6 +34,10 @@ function variantSegments(raw: string): string[] {
   return raw.split(":").slice(0, -1);
 }
 
+function isAnimateBase(base: string): boolean {
+  return base.startsWith("animate-");
+}
+
 export function extractReducedMotionChecks(code: string, filePath: string): ReducedMotionCheck[] {
   const ast = parseJSX(code, filePath);
   if (!ast) return [];
@@ -52,12 +56,32 @@ export function extractReducedMotionChecks(code: string, filePath: string): Redu
       const hasInteractionClass = classes.some((raw) =>
         variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v))
       );
+      // A second, independent candidacy path for animate-* utilities, which
+      // carry their own `animation` property and need no transition-*  base
+      // at all -- `hover:animate-bounce` alone must be a candidate even
+      // though `hasTransitionBase` is false. Deliberately a SINGLE-class
+      // condition (one class must be both an animate-* base AND
+      // interaction-scoped in its own variant stack), not two independent
+      // whole-element flags like hasTransitionBase/hasInteractionClass
+      // above: unlike transition-transform (never itself interaction-scoped)
+      // paired with a separate hover:scale-110, an animate-* class is
+      // simultaneously its own trigger and its own animator. Two independent
+      // flags would wrongly treat `animate-spin hover:text-red-500` (an
+      // unscoped, continuously-running animation next to an unrelated hover
+      // class) as a candidate -- that's 2.2.2 (Pause/Stop/Hide) territory,
+      // not 2.3.3, per the same reasoning checkReducedMotion.ts already
+      // documents for why unscoped animate-* is out of scope here.
+      const hasInteractionScopedAnimate = classes.some((raw) => {
+        const base = baseUtility(raw);
+        return isAnimateBase(base) && variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v));
+      });
       // Not a candidate at all unless there's some transition utility
-      // (scoped or not) *and* some interaction-scoped class -- narrows the
-      // set of elements checkReducedMotion.ts has to reason about, without
-      // pre-deciding any of the nuance (unscoped vs motion-safe:, identity
-      // values, motion-reduce: guards) that belongs in the rule.
-      if (!hasTransitionBase || !hasInteractionClass) return;
+      // (scoped or not) *and* some interaction-scoped class, OR an
+      // interaction-scoped animate-* class -- narrows the set of elements
+      // checkReducedMotion.ts has to reason about, without pre-deciding any
+      // of the nuance (unscoped vs motion-safe:, identity/non-motion
+      // animate-* names, motion-reduce: guards) that belongs in the rule.
+      if ((!hasTransitionBase || !hasInteractionClass) && !hasInteractionScopedAnimate) return;
 
       checks.push({
         file: filePath,

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
@@ -22,6 +22,7 @@ describe("checkReducedMotion", () => {
     expect(violations).toEqual([
       {
         type: "reduced-motion",
+        mechanism: "transition",
         file: "f.tsx",
         line: 1,
         tagName: "div",
@@ -64,7 +65,7 @@ describe("checkReducedMotion", () => {
     (transitionClass) => {
       const violations = checkReducedMotion([check([transitionClass, "hover:scale-110"])], true);
       expect(violations).toHaveLength(1);
-      expect(violations[0].transitionClass).toBe(transitionClass);
+      expect(violations[0]).toMatchObject({ mechanism: "transition", transitionClass });
     }
   );
 
@@ -162,5 +163,90 @@ describe("checkReducedMotion", () => {
     const violations = checkReducedMotion(extractReducedMotionChecks(code, "fake.tsx"), true);
     expect(violations).toHaveLength(1);
     expect(violations[0].type).toBe("reduced-motion");
+  });
+
+  describe("animate-* mechanism", () => {
+    it.each(["hover:animate-bounce", "hover:animate-spin", "hover:animate-ping"])(
+      "flags an interaction-scoped animate-* class alone, with no transition base at all: %s",
+      (animateClass) => {
+        const violations = checkReducedMotion([check([animateClass])], true);
+        expect(violations).toEqual([
+          {
+            type: "reduced-motion",
+            mechanism: "animate",
+            file: "f.tsx",
+            line: 1,
+            tagName: "div",
+            motionClass: animateClass,
+            level: "AAA",
+          },
+        ]);
+      }
+    );
+
+    it("does not flag hover:animate-pulse -- opacity-only, not a size/shape/position change", () => {
+      const violations = checkReducedMotion([check(["hover:animate-pulse"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it("does not flag hover:animate-none -- the off/identity value", () => {
+      const violations = checkReducedMotion([check(["hover:animate-none"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it("does not flag an unscoped animate-bounce with no interaction variant (2.2.2 territory, out of scope here)", () => {
+      const violations = checkReducedMotion([check(["animate-bounce"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it("does not flag an unscoped animate-bounce alongside an unrelated interaction-scoped class on the same element", () => {
+      const violations = checkReducedMotion([check(["animate-bounce", "hover:text-red-500"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it("passes when a bare motion-reduce:animate-none guard is present", () => {
+      const violations = checkReducedMotion([check(["hover:animate-bounce", "motion-reduce:animate-none"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it("does not accept a motion-reduce:animate-none guard nested under an unrelated variant (regression, mirrors the transition-side guard)", () => {
+      const violations = checkReducedMotion([check(["hover:animate-bounce", "sm:motion-reduce:animate-none"])], true);
+      expect(violations).toHaveLength(1);
+    });
+
+    it("a bare motion-reduce:transition-none guard does not suppress an animate-mechanism violation (independent guards)", () => {
+      const violations = checkReducedMotion([check(["hover:animate-bounce", "motion-reduce:transition-none"])], true);
+      expect(violations).toHaveLength(1);
+    });
+
+    it.each(["motion-safe:hover:animate-bounce", "hover:motion-safe:animate-bounce"])(
+      "passes when the interaction-scoped animate-* is itself motion-safe:-guarded, in either variant order: %s",
+      (animateClass) => {
+        const violations = checkReducedMotion([check([animateClass])], true);
+        expect(violations).toEqual([]);
+      }
+    );
+
+    it("still flags animate-bounce scoped by an unrelated persistent variant stacked with the interaction variant", () => {
+      const violations = checkReducedMotion([check(["dark:hover:animate-bounce"])], true);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].motionClass).toBe("dark:hover:animate-bounce");
+    });
+
+    it("produces two independent violations when an element has both a real transition violation and a real animate violation", () => {
+      const violations = checkReducedMotion(
+        [check(["transition-transform", "hover:scale-110", "focus:animate-bounce"])],
+        true
+      );
+      expect(violations).toHaveLength(2);
+      expect(violations.map((v) => v.mechanism).sort()).toEqual(["animate", "transition"]);
+    });
+
+    it("composes end-to-end with extractReducedMotionChecks for an animate-only element", () => {
+      const code = `const C = () => <div className="hover:animate-bounce">x</div>;`;
+      const violations = checkReducedMotion(extractReducedMotionChecks(code, "fake.tsx"), true);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].mechanism).toBe("animate");
+    });
   });
 });

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
@@ -1,14 +1,33 @@
 import type { ReducedMotionCheck } from "../parser/extractReducedMotion.js";
 
-export interface ReducedMotionViolation {
-  type: "reduced-motion";
-  file: string;
-  line: number;
-  tagName: string;
-  transitionClass: string;
-  motionClass: string;
-  level: "AAA"; // no AA tier exists for this SC to fall back to
-}
+// Two independently-detected mechanisms under one WCAG 2.3.3 citation, not
+// one enriched shape: a transition-mechanism violation always has a real
+// transitionClass; an animate-mechanism violation has none at all (animate-*
+// utilities carry their own `animation` property and are simultaneously
+// their own trigger and their own animator -- there is no separate
+// transition utility to name, so reusing `transitionClass` with the animate
+// class itself would read as "animates X via X"). Both can fire on the same
+// element independently.
+export type ReducedMotionViolation =
+  | {
+      type: "reduced-motion";
+      mechanism: "transition";
+      file: string;
+      line: number;
+      tagName: string;
+      transitionClass: string;
+      motionClass: string;
+      level: "AAA"; // no AA tier exists for this SC to fall back to
+    }
+  | {
+      type: "reduced-motion";
+      mechanism: "animate";
+      file: string;
+      line: number;
+      tagName: string;
+      motionClass: string;
+      level: "AAA";
+    };
 
 // Verified against a real Tailwind v4 build: only these three include
 // transform/translate/scale/rotate in their transition-property list.
@@ -56,6 +75,18 @@ function isNonIdentityMotionUtility(base: string): boolean {
   if (skew) return Number(skew[2]) !== 0;
   return false;
 }
+
+// Verified against a real Tailwind v4 build's compiled keyframes:
+// animate-spin -> rotate(360deg) (orientation/shape change), animate-ping ->
+// scale(2)+opacity:0 (includes a size change), animate-bounce ->
+// translateY(-25%) (position change) -- all three qualify as "motion
+// animation" per this project's own WCAG 2.3.3 boundary (size/shape/
+// position, not color/opacity/blur). animate-pulse is opacity-only (excluded,
+// same reason color/opacity transitions don't count above) and animate-none
+// is the off/identity value (excluded, same treatment as scale-100/rotate-0).
+// A fully enumerated set, not a regex -- unlike scale/rotate/translate/skew,
+// none of these utilities take an arbitrary numeric value to range-check.
+const ANIMATE_MOTION_BASES = new Set(["animate-spin", "animate-ping", "animate-bounce"]);
 
 // `strict` gates the whole check for the scan-everything-by-default
 // adapters (CLI/VS Code/GitHub Action) -- WCAG 2.3.3 is AAA-only, and
@@ -126,6 +157,38 @@ export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false)
       }
     }
 
+    // Independent detection path for the animate-* mechanism -- deliberately
+    // NOT nested after the transition path's `continue`s below, since
+    // `hover:animate-bounce` alone has no transition base at all
+    // (realTransition stays null), which would skip past this block entirely
+    // if it were placed after the `if (!realTransition) continue;` line. A
+    // single element can have a real violation on both mechanisms at once
+    // (independently pushed), or on just one -- they don't race for one slot.
+    const hasMotionReduceAnimateGuard = check.classes.some((raw) => {
+      const segments = variantSegments(raw);
+      return segments.length === 1 && segments[0] === "motion-reduce" && baseUtility(raw) === "animate-none";
+    });
+    const animateMotionClass = check.classes.find((raw) => {
+      const segments = variantSegments(raw);
+      // Same self-guard and interaction-scoping reasoning as the transition
+      // side's motionClass find below -- see its comment for the full
+      // explanation of why both checks are per-candidate, not per-element.
+      if (segments.includes("motion-safe")) return false;
+      if (!segments.some((v) => INTERACTION_VARIANTS.has(v))) return false;
+      return ANIMATE_MOTION_BASES.has(baseUtility(raw));
+    });
+    if (animateMotionClass && !hasMotionReduceAnimateGuard) {
+      violations.push({
+        type: "reduced-motion",
+        mechanism: "animate",
+        file: check.file,
+        line: check.line,
+        tagName: check.tagName,
+        motionClass: animateMotionClass,
+        level: "AAA",
+      });
+    }
+
     // No real (non-motion-safe-guarded) transition at all means it simply
     // doesn't exist unless motion is already safe -- a complete
     // alternative way of satisfying 2.3.3, not a partial one -- so this
@@ -149,6 +212,7 @@ export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false)
 
     violations.push({
       type: "reduced-motion",
+      mechanism: "transition",
       file: check.file,
       line: check.line,
       tagName: check.tagName,

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -15,7 +15,7 @@ reimplemented here.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |
-| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform` and no `motion-reduce:`/`motion-safe:` handling |
+| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
 (debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.13.5"
+    "tailwind-a11y": "^0.14.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/vscode-tailwind-a11y/src/format.test.ts
+++ b/packages/vscode-tailwind-a11y/src/format.test.ts
@@ -111,9 +111,10 @@ describe("formatViolation", () => {
     );
   });
 
-  it("formats a reduced-motion violation", () => {
+  it("formats a reduced-motion violation (transition mechanism)", () => {
     const message = formatViolation({
       type: "reduced-motion",
+      mechanism: "transition",
       file: "f.tsx",
       line: 1,
       tagName: "div",
@@ -123,6 +124,21 @@ describe("formatViolation", () => {
     });
     expect(message).toBe(
       "<div> animates hover:scale-110 via transition-transform with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
+    );
+  });
+
+  it("formats a reduced-motion violation (animate mechanism)", () => {
+    const message = formatViolation({
+      type: "reduced-motion",
+      mechanism: "animate",
+      file: "f.tsx",
+      line: 1,
+      tagName: "div",
+      motionClass: "hover:animate-bounce",
+      level: "AAA",
+    });
+    expect(message).toBe(
+      "<div> animates hover:animate-bounce via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable"
     );
   });
 });

--- a/packages/vscode-tailwind-a11y/src/format.ts
+++ b/packages/vscode-tailwind-a11y/src/format.ts
@@ -37,6 +37,8 @@ export function formatViolation(v: AnyViolation): string {
         : base;
     }
     case "reduced-motion":
-      return `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
+      return v.mechanism === "animate"
+        ? `<${v.tagName}> animates ${v.motionClass} via a CSS animation with no motion-reduce:animate-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`
+        : `<${v.tagName}> animates ${v.motionClass} via ${v.transitionClass} with no motion-reduce:transition-none/transform-none guard — WCAG 2.3.3 requires motion animation triggered by interaction to be disableable`;
   }
 }


### PR DESCRIPTION
## What

Adds a second, independent detection mechanism to the existing reduced-motion check (WCAG 2.3.3, AAA-only, gated behind `strict`): interaction-scoped `animate-*` utilities like `hover:animate-bounce`, `hover:animate-spin`, and `hover:animate-ping`. An element can now produce a transition-mechanism violation, an animate-mechanism violation, or both independently, since they're genuinely separate problems rather than competing for one reported slot.

## Why

`animate-*` utilities carry their own `animation` CSS property and need no `transition-*` base at all, so `hover:animate-bounce` alone previously produced zero checks in any mode — the extractor's candidacy gate required a transition base this pattern never has. This was a documented, known gap in the engine package's own CLAUDE.md, found during an earlier adversarial review pass and left unimplemented at the time. `ANIMATE_MOTION_BASES` (spin/ping/bounce) is verified against real Tailwind v4 compiled keyframes — spin rotates, ping scales, bounce translates, all qualifying as WCAG 2.3.3 "motion" under this project's own already-established size/shape/position boundary. `animate-pulse` (opacity-only) and `animate-none` (the off value) are excluded, matching the treatment `scale-100`/`rotate-0` already get on the transition side. The new guard, a bare `motion-reduce:animate-none`, is kept fully independent from the existing transition-side guard so one mechanism can never suppress the other's violation.

## Versions

`tailwind-a11y`, `eslint-plugin-tailwind-a11y`, and `github-action-tailwind-a11y` go from 0.13.5 to 0.14.0; `vscode-tailwind-a11y` goes from 0.14.5 to 0.15.0, staying one minor ahead per this project's established convention. The GitHub Action's committed `dist/index.js` bundle is rebuilt and included.

