### PR TITLE
Recognize group-*/peer-* interaction variants in reduced-motion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.13.5`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.14.1`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.14.0"
+        "tailwind-a11y": "^0.14.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.14.0"
+        "tailwind-a11y": "^0.14.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.14.0"
+        "tailwind-a11y": "^0.14.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -46,7 +46,7 @@ export default [
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |
-| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
+| `reduced-motion` | 2.3.3 (AAA-only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped (or their `group-*`/`peer-*` equivalents) `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling — **not** included in `configs.recommended`, see below |
 
 Exact scope and known limitations: [engine README](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y#scope).
 

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.14.0"
+    "tailwind-a11y": "^0.14.1"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -50027,7 +50027,29 @@ function checkFocusContrast(checks, strict = false, palette = defaultPalette) {
 // ../tailwind-a11y/dist/parser/extractReducedMotion.js
 var t6 = __toESM(require_lib3(), 1);
 var TRANSITION_BASES = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
-var INTERACTION_VARIANTS = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+var INTERACTION_VARIANTS = /* @__PURE__ */ new Set([
+  "hover",
+  "focus",
+  "focus-visible",
+  "focus-within",
+  "active",
+  "group-hover",
+  "group-focus",
+  "group-focus-visible",
+  "group-focus-within",
+  "group-active",
+  "peer-hover",
+  "peer-focus",
+  "peer-focus-visible",
+  "peer-focus-within",
+  "peer-active"
+]);
+function isInteractionVariant(v) {
+  if (INTERACTION_VARIANTS.has(v))
+    return true;
+  const slash = v.indexOf("/");
+  return slash !== -1 && INTERACTION_VARIANTS.has(v.slice(0, slash));
+}
 function baseUtility2(raw) {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -50050,10 +50072,10 @@ function extractReducedMotionChecks(code, filePath) {
         return;
       const classes = className.split(/\s+/).filter(Boolean);
       const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility2(raw)));
-      const hasInteractionClass = classes.some((raw) => variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v)));
+      const hasInteractionClass = classes.some((raw) => variantSegments(raw).some(isInteractionVariant));
       const hasInteractionScopedAnimate = classes.some((raw) => {
         const base = baseUtility2(raw);
-        return isAnimateBase(base) && variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v));
+        return isAnimateBase(base) && variantSegments(raw).some(isInteractionVariant);
       });
       if ((!hasTransitionBase || !hasInteractionClass) && !hasInteractionScopedAnimate)
         return;
@@ -50070,7 +50092,29 @@ function extractReducedMotionChecks(code, filePath) {
 
 // ../tailwind-a11y/dist/rules/checkReducedMotion.js
 var TRANSITION_BASES2 = /* @__PURE__ */ new Set(["transition", "transition-all", "transition-transform"]);
-var INTERACTION_VARIANTS2 = /* @__PURE__ */ new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+var INTERACTION_VARIANTS2 = /* @__PURE__ */ new Set([
+  "hover",
+  "focus",
+  "focus-visible",
+  "focus-within",
+  "active",
+  "group-hover",
+  "group-focus",
+  "group-focus-visible",
+  "group-focus-within",
+  "group-active",
+  "peer-hover",
+  "peer-focus",
+  "peer-focus-visible",
+  "peer-focus-within",
+  "peer-active"
+]);
+function isInteractionVariant2(v) {
+  if (INTERACTION_VARIANTS2.has(v))
+    return true;
+  const slash = v.indexOf("/");
+  return slash !== -1 && INTERACTION_VARIANTS2.has(v.slice(0, slash));
+}
 function baseUtility3(raw) {
   return raw.slice(raw.lastIndexOf(":") + 1);
 }
@@ -50107,7 +50151,7 @@ function checkReducedMotion(checks, strict = false) {
     for (const raw of check.classes) {
       const base = baseUtility3(raw);
       const segments = variantSegments2(raw);
-      const isInteractionGated = segments.some((v) => INTERACTION_VARIANTS2.has(v));
+      const isInteractionGated = segments.some(isInteractionVariant2);
       const isMotionSafeGated = segments.includes("motion-safe");
       if (TRANSITION_BASES2.has(base) && !isInteractionGated && !isMotionSafeGated)
         realTransition = raw;
@@ -50123,7 +50167,7 @@ function checkReducedMotion(checks, strict = false) {
       const segments = variantSegments2(raw);
       if (segments.includes("motion-safe"))
         return false;
-      if (!segments.some((v) => INTERACTION_VARIANTS2.has(v)))
+      if (!segments.some(isInteractionVariant2))
         return false;
       return ANIMATE_MOTION_BASES.has(baseUtility3(raw));
     });
@@ -50146,7 +50190,7 @@ function checkReducedMotion(checks, strict = false) {
       const segments = variantSegments2(raw);
       if (segments.includes("motion-safe"))
         return false;
-      if (!segments.some((v) => INTERACTION_VARIANTS2.has(v)))
+      if (!segments.some(isInteractionVariant2))
         return false;
       return isNonIdentityMotionUtility(baseUtility3(raw));
     });

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.14.0",
+    "tailwind-a11y": "^0.14.1",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -345,7 +345,20 @@ Tailwind-class-level sizing or focus-style analysis).
     card is exactly the target case), so it walks every JSX element with a
     static `className`, same as `extractClasses.ts`'s contrast check.
     Interaction variants recognized: `hover`/`focus`/`focus-visible`/
-    `focus-within`/`active`.
+    `focus-within`/`active`, plus their `group-*`/`peer-*` equivalents
+    (`group-hover`/`group-focus`/`group-focus-visible`/`group-focus-within`/
+    `group-active` and the `peer-*` set) — verified against a real v4 build
+    that these compile to the identical momentary-pseudo-class shape as bare
+    `hover:`, just evaluated against an ancestor/sibling `.group`/`.peer`
+    marker instead of the element itself, so all the same reasoning applies
+    unchanged. Named groups/peers (`group-hover/sidebar:scale-110`) are also
+    recognized — Tailwind compiles the name into the variant token itself via
+    a slash, so matching checks the segment verbatim first, then the prefix
+    before its first `/`. Deliberately **not** extended to `has-*:`/arbitrary
+    variants (`[&:hover]:`, already out of scope elsewhere in this file —
+    unbounded selector text, not a closed enumerable set) or `in-*:` (a real
+    v4.1+ ancestor-state variant with the identical shape — a legitimate
+    separate follow-up, not folded into this set).
   - Variant detection scans **every** segment of a stacked variant class
     (`variantSegments()`), not just the one immediately before the base
     utility — caught in independent review: `motion-safe:hover:scale-110`

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -57,7 +57,7 @@ Exits `1` on violations — safe to use as a CI gate.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |
-| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
+| Reduced motion | 2.3.3 (AAA, `--strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped (or their `group-*`/`peer-*` equivalents) `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
 
 ## Scope
 

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.test.ts
@@ -96,4 +96,51 @@ describe("extractReducedMotionChecks", () => {
     const code = `const C = () => <div className="hover:animate-pulse">x</div>;`;
     expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
   });
+
+  it.each([
+    "group-hover:scale-110",
+    "group-focus:scale-110",
+    "group-focus-visible:scale-110",
+    "group-focus-within:scale-110",
+    "group-active:scale-110",
+    "peer-hover:scale-110",
+    "peer-focus:scale-110",
+    "peer-focus-visible:scale-110",
+    "peer-focus-within:scale-110",
+    "peer-active:scale-110",
+  ])("recognizes %s as an interaction variant on the transition path", (groupClass) => {
+    const code = `const C = () => <div className="transition-transform ${groupClass}">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it.each(["group-hover:animate-bounce", "peer-hover:animate-bounce"])(
+    "recognizes %s as an interaction variant on the animate path, no transition base at all",
+    (animateClass) => {
+      const code = `const C = () => <div className="${animateClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+    }
+  );
+
+  it("recognizes a named group variant (group-hover/sidebar:) as an interaction variant", () => {
+    const code = `const C = () => <div className="transition-transform group-hover/sidebar:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+  });
+
+  it.each(["motion-safe:group-hover:scale-110", "group-hover:motion-safe:scale-110"])(
+    "recognizes group-hover: regardless of its position relative to motion-safe:, e.g. %s (rule decides pass/fail)",
+    (stackedClass) => {
+      const code = `const C = () => <div className="transition-transform ${stackedClass}">x</div>;`;
+      expect(extractReducedMotionChecks(code, "fake.tsx")).toHaveLength(1);
+    }
+  );
+
+  it("does not treat a near-miss variant as interaction-scoped -- exact-or-prefix-before-slash only, not a substring match", () => {
+    const code = `const C = () => <div className="transition-transform group-hoverish:scale-110">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
+
+  it("skips a plain group marker class with no group-hover: variant anywhere", () => {
+    const code = `const C = () => <div className="group transition-transform">x</div>;`;
+    expect(extractReducedMotionChecks(code, "fake.tsx")).toEqual([]);
+  });
 });

--- a/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
+++ b/packages/tailwind-a11y/src/parser/extractReducedMotion.ts
@@ -15,7 +15,35 @@ export interface ReducedMotionCheck {
 }
 
 const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
-const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+// group-hover:/peer-hover:/etc. compile to the identical momentary-pseudo-
+// class shape as bare hover:, just evaluated against an ancestor/sibling
+// (.group/.peer marker) instead of the element itself -- verified against a
+// real Tailwind v4 build (`.group-hover\:scale-110:is(:where(.group):hover *)`).
+// Deliberately NOT extended to has-*:/arbitrary variants ([&:hover]:, already
+// an established out-of-scope precedent for this file -- unbounded selector
+// text, not a closed enumerable set) or in-*: (a real v4.1+ ancestor-state
+// variant with the identical shape, but a legitimate separate follow-up, not
+// folded into this set).
+const INTERACTION_VARIANTS = new Set([
+  "hover", "focus", "focus-visible", "focus-within", "active",
+  "group-hover", "group-focus", "group-focus-visible", "group-focus-within", "group-active",
+  "peer-hover", "peer-focus", "peer-focus-visible", "peer-focus-within", "peer-active",
+]);
+
+// Named groups/peers (`group-hover/sidebar:scale-110`) compile the group
+// name into the variant token itself via a slash
+// (`.group-hover\/sidebar\:scale-110:is(:where(.group\/sidebar):hover *)`),
+// so variantSegments() returns "group-hover/sidebar" verbatim -- a plain
+// Set.has() would miss it. Safe to slice on the first "/" and re-check:
+// Tailwind's opacity-modifier slash (`text-black/50`) lives inside the base
+// utility segment (after the last ":"), never inside a variant segment, so
+// there's no collision to worry about here.
+function isInteractionVariant(v: string): boolean {
+  if (INTERACTION_VARIANTS.has(v)) return true;
+  const slash = v.indexOf("/");
+  return slash !== -1 && INTERACTION_VARIANTS.has(v.slice(0, slash));
+}
 
 function baseUtility(raw: string): string {
   return raw.slice(raw.lastIndexOf(":") + 1);
@@ -53,9 +81,7 @@ export function extractReducedMotionChecks(code: string, filePath: string): Redu
       const classes = className.split(/\s+/).filter(Boolean);
 
       const hasTransitionBase = classes.some((raw) => TRANSITION_BASES.has(baseUtility(raw)));
-      const hasInteractionClass = classes.some((raw) =>
-        variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v))
-      );
+      const hasInteractionClass = classes.some((raw) => variantSegments(raw).some(isInteractionVariant));
       // A second, independent candidacy path for animate-* utilities, which
       // carry their own `animation` property and need no transition-*  base
       // at all -- `hover:animate-bounce` alone must be a candidate even
@@ -73,7 +99,7 @@ export function extractReducedMotionChecks(code: string, filePath: string): Redu
       // documents for why unscoped animate-* is out of scope here.
       const hasInteractionScopedAnimate = classes.some((raw) => {
         const base = baseUtility(raw);
-        return isAnimateBase(base) && variantSegments(raw).some((v) => INTERACTION_VARIANTS.has(v));
+        return isAnimateBase(base) && variantSegments(raw).some(isInteractionVariant);
       });
       // Not a candidate at all unless there's some transition utility
       // (scoped or not) *and* some interaction-scoped class, OR an

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.test.ts
@@ -249,4 +249,83 @@ describe("checkReducedMotion", () => {
       expect(violations[0].mechanism).toBe("animate");
     });
   });
+
+  describe("group-*/peer-* interaction variants", () => {
+    it.each(["group-hover:scale-110", "peer-hover:scale-110"])(
+      "flags %s under an unscoped transition, same as bare hover:",
+      (motionClass) => {
+        const violations = checkReducedMotion([check(["transition-transform", motionClass])], true);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]).toMatchObject({ mechanism: "transition", motionClass });
+      }
+    );
+
+    it("passes when the transition itself is group-scoped (not present in the resting state)", () => {
+      const violations = checkReducedMotion(
+        [check(["group-hover:transition-transform", "group-hover:scale-110"])],
+        true
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it("passes when a bare motion-reduce:transition-none guard is present alongside a group-hover: motion class", () => {
+      const violations = checkReducedMotion(
+        [check(["transition-transform", "group-hover:scale-110", "motion-reduce:transition-none"])],
+        true
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it.each(["group-hover:animate-bounce", "peer-hover:animate-bounce"])(
+      "flags %s on the animate mechanism, no transition base at all",
+      (motionClass) => {
+        const violations = checkReducedMotion([check([motionClass])], true);
+        expect(violations).toHaveLength(1);
+        expect(violations[0]).toMatchObject({ mechanism: "animate", motionClass });
+      }
+    );
+
+    it("passes with a bare motion-reduce:animate-none guard alongside a group-hover: animate class", () => {
+      const violations = checkReducedMotion([check(["group-hover:animate-bounce", "motion-reduce:animate-none"])], true);
+      expect(violations).toEqual([]);
+    });
+
+    it.each(["group-hover:motion-safe:scale-110", "motion-safe:group-hover:scale-110"])(
+      "passes when the group-hover: motion utility is itself motion-safe:-guarded, in either variant order: %s",
+      (motionClass) => {
+        const violations = checkReducedMotion([check(["transition-transform", motionClass])], true);
+        expect(violations).toEqual([]);
+      }
+    );
+
+    it("passes when a named-group motion utility is itself motion-safe:-guarded", () => {
+      const violations = checkReducedMotion(
+        [check(["transition-transform", "group-hover/sidebar:motion-safe:scale-110"])],
+        true
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it("still flags group-hover:scale-110 scoped by an unrelated persistent variant stacked with it", () => {
+      const violations = checkReducedMotion([check(["transition-transform", "sm:group-hover:scale-110"])], true);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].motionClass).toBe("sm:group-hover:scale-110");
+    });
+
+    it("flags a named-group motion utility, echoing the raw class (including the /sidebar suffix) verbatim", () => {
+      const violations = checkReducedMotion(
+        [check(["transition-transform", "group-hover/sidebar:scale-110"])],
+        true
+      );
+      expect(violations).toHaveLength(1);
+      expect(violations[0].motionClass).toBe("group-hover/sidebar:scale-110");
+    });
+
+    it("composes end-to-end with extractReducedMotionChecks for a group-hover-only element", () => {
+      const code = `const C = () => <div className="group-hover:animate-bounce">x</div>;`;
+      const violations = checkReducedMotion(extractReducedMotionChecks(code, "fake.tsx"), true);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].mechanism).toBe("animate");
+    });
+  });
 });

--- a/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
+++ b/packages/tailwind-a11y/src/rules/checkReducedMotion.ts
@@ -36,7 +36,26 @@ export type ReducedMotionViolation =
 // animates (the browser has nothing telling it to transition that
 // property), and correctly isn't flagged.
 const TRANSITION_BASES = new Set(["transition", "transition-all", "transition-transform"]);
-const INTERACTION_VARIANTS = new Set(["hover", "focus", "focus-visible", "focus-within", "active"]);
+
+// group-hover:/peer-hover:/etc. compile to the identical momentary-pseudo-
+// class shape as bare hover:, just evaluated against an ancestor/sibling
+// (.group/.peer marker) instead of the element itself -- see the identical
+// set (and full explanation) in extractReducedMotion.ts. Deliberately NOT
+// extended to has-*:/arbitrary variants or in-*: -- see that file's comment.
+const INTERACTION_VARIANTS = new Set([
+  "hover", "focus", "focus-visible", "focus-within", "active",
+  "group-hover", "group-focus", "group-focus-visible", "group-focus-within", "group-active",
+  "peer-hover", "peer-focus", "peer-focus-visible", "peer-focus-within", "peer-active",
+]);
+
+// Named groups/peers (`group-hover/sidebar:...`) put the group name in the
+// variant token itself via a slash -- see extractReducedMotion.ts for the
+// full explanation of why slicing on the first "/" is safe here.
+function isInteractionVariant(v: string): boolean {
+  if (INTERACTION_VARIANTS.has(v)) return true;
+  const slash = v.indexOf("/");
+  return slash !== -1 && INTERACTION_VARIANTS.has(v.slice(0, slash));
+}
 
 function baseUtility(raw: string): string {
   return raw.slice(raw.lastIndexOf(":") + 1);
@@ -135,7 +154,7 @@ export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false)
       // `dark:transition hover:scale-110` was silently treated as
       // compliant even though it animates on hover in dark mode
       // regardless of the user's motion preference.
-      const isInteractionGated = segments.some((v) => INTERACTION_VARIANTS.has(v));
+      const isInteractionGated = segments.some(isInteractionVariant);
       const isMotionSafeGated = segments.includes("motion-safe");
       if (TRANSITION_BASES.has(base) && !isInteractionGated && !isMotionSafeGated) realTransition = raw;
 
@@ -174,7 +193,7 @@ export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false)
       // side's motionClass find below -- see its comment for the full
       // explanation of why both checks are per-candidate, not per-element.
       if (segments.includes("motion-safe")) return false;
-      if (!segments.some((v) => INTERACTION_VARIANTS.has(v))) return false;
+      if (!segments.some(isInteractionVariant)) return false;
       return ANIMATE_MOTION_BASES.has(baseUtility(raw));
     });
     if (animateMotionClass && !hasMotionReduceAnimateGuard) {
@@ -205,7 +224,7 @@ export function checkReducedMotion(checks: ReducedMotionCheck[], strict = false)
       // for the whole element (a class can be interaction-scoped *and*
       // self-guarded at the same time, e.g. `hover:motion-safe:scale-110`).
       if (segments.includes("motion-safe")) return false;
-      if (!segments.some((v) => INTERACTION_VARIANTS.has(v))) return false;
+      if (!segments.some(isInteractionVariant)) return false;
       return isNonIdentityMotionUtility(baseUtility(raw));
     });
     if (!motionClass) continue; // no real, un-self-guarded motion actually triggered by interaction

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -15,7 +15,7 @@ reimplemented here.
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |
-| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
+| Reduced motion | 2.3.3 (AAA-only, `tailwind-a11y.strict` only) | A `hover:`/`focus:`/`focus-visible:`/`active:`-scoped (or their `group-*`/`peer-*` equivalents) `scale-*`/`rotate-*`/`translate-*`/`skew-*` change with an unscoped `transition`/`transition-all`/`transition-transform`, or an `animate-spin`/`-ping`/`-bounce` under the same variants, with no `motion-reduce:`/`motion-safe:` handling |
 
 Diagnostics appear as warnings in `.jsx`/`.tsx` files, updating on open, save, and
 (debounced) as you type. For CI enforcement, use the [CLI](https://github.com/chamroro/tailwind-a11y/tree/main/packages/tailwind-a11y)

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.14.0"
+    "tailwind-a11y": "^0.14.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## What

Widens the set of Tailwind variants the reduced-motion check (WCAG 2.3.3) recognizes as "interaction-triggered" to include `group-hover:`, `group-focus:`, `group-focus-visible:`, `group-focus-within:`, `group-active:`, the equivalent `peer-*:` set, and their named-group/peer forms (`group-hover/sidebar:`).

## Why

`group-hover:`/`peer-hover:`/etc. compile to the identical momentary pseudo-class shape as bare `hover:` — just evaluated against an ancestor or sibling marker element instead of the element itself, verified against real Tailwind v4 compiled output. But the check's `INTERACTION_VARIANTS` set only ever recognized bare `hover:`/`focus:`/`focus-visible:`/`focus-within:`/`active:`, so the extremely common "parent has `class=\"group\"`, child reacts to the parent's hover state" pattern produced zero checks, a full miss on a real-world-common case rather than a deliberate exclusion. Named groups compile the group name directly into the variant token via a slash, so a plain set lookup needed a small prefix-matching helper to catch those too. This is purely a recognition widening — no new violation shape, no new field, no consumer-facing message change — so it ships as a patch, matching this project's own precedent for prior fixes of this shape.

## Versions

`tailwind-a11y`, `eslint-plugin-tailwind-a11y`, and `github-action-tailwind-a11y` go from 0.14.0 to 0.14.1; `vscode-tailwind-a11y` goes from 0.15.0 to 0.15.1. The GitHub Action's committed `dist/index.js` bundle is rebuilt and included.

## Test plan

`npm test --workspaces` passes across all four packages (492 tests). The direct repro (`<div className="group"><span className="group-hover:scale-110 transition-transform">`) now correctly flags where it previously produced nothing, verified against the built CLI. New coverage spans every group-*/peer-* variant on both the transition and animate mechanisms, named-group recognition, a deliberate near-miss (`group-hoverish:`) confirming the match isn't a substring check, guard and self-guard behavior mirroring the existing bare-hover coverage, and an unrelated persistent variant stacked with a group-scoped interaction variant still flagging correctly.