### PR TITLE
Check placeholder:text-* contrast on input/textarea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ another check) should follow the same pattern.
   from the engine's build output, so that order fails. When adding a package, append it
   in dependency order.
 - **`eslint-plugin-tailwind-a11y`'s dependency on `tailwind-a11y` is a plain semver range
-  (`^0.14.1`), not a special workspace protocol** — npm has no `workspace:` protocol.
+  (`^0.15.0`), not a special workspace protocol** — npm has no `workspace:` protocol.
   npm resolves it to the local workspace symlink only while the range is satisfied by
   the engine's actual `version`. Bump both together; `npm run check:link` at the root
   guards against this drifting silently (a version bump that breaks the range makes npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -6457,10 +6457,10 @@
       }
     },
     "packages/eslint-plugin-tailwind-a11y": {
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.14.1"
+        "tailwind-a11y": "^0.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6476,11 +6476,11 @@
       }
     },
     "packages/github-action-tailwind-a11y": {
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
-        "tailwind-a11y": "^0.14.1"
+        "tailwind-a11y": "^0.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6490,7 +6490,7 @@
       }
     },
     "packages/tailwind-a11y": {
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.0",
@@ -6514,10 +6514,10 @@
       }
     },
     "packages/vscode-tailwind-a11y": {
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
-        "tailwind-a11y": "^0.14.1"
+        "tailwind-a11y": "^0.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/eslint-plugin-tailwind-a11y/README.md
+++ b/packages/eslint-plugin-tailwind-a11y/README.md
@@ -42,7 +42,7 @@ export default [
 
 | Rule | WCAG | Detects |
 |---|---|---|
-| `contrast` | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — suggests the nearest passing shade |
+| `contrast` | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs, plus `placeholder:text-*` on `<input>`/`<textarea>` — suggests the nearest passing shade |
 | `touch-target` | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `{ strict: true }` (2.5.5, AAA) |
 | `focus-indicator` | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | `focus-contrast` | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `{ strict: true }` (2.4.13, AAA) |

--- a/packages/eslint-plugin-tailwind-a11y/package.json
+++ b/packages/eslint-plugin-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tailwind-a11y",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "ESLint rules that catch WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations.",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/chamroro/tailwind-a11y/tree/main/packages/eslint-plugin-tailwind-a11y#readme",
   "dependencies": {
-    "tailwind-a11y": "^0.14.1"
+    "tailwind-a11y": "^0.15.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/github-action-tailwind-a11y/dist/index.js
+++ b/packages/github-action-tailwind-a11y/dist/index.js
@@ -49172,6 +49172,12 @@ function getStaticClassName(attributes) {
 // ../tailwind-a11y/dist/parser/extractClasses.js
 var COLOR_TOKEN = /^\[(#[0-9a-fA-F]{3,8})\](\/\d{1,3})?$|^[a-z]+-\d{2,3}(\/\d{1,3})?$|^(white|black|transparent|current|inherit)(\/\d{1,3})?$/;
 var NON_COLOR_SCALE_NAMES = /* @__PURE__ */ new Set(["opacity", "linear", "conic"]);
+function isColorScaleToken(rest) {
+  if (!COLOR_TOKEN.test(rest))
+    return false;
+  const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
+  return !(scaleName && NON_COLOR_SCALE_NAMES.has(scaleName));
+}
 function lastColorToken(className, prefix) {
   let found = null;
   for (const raw of className.split(/\s+/).filter(Boolean)) {
@@ -49180,14 +49186,45 @@ function lastColorToken(className, prefix) {
     if (!raw.startsWith(`${prefix}-`))
       continue;
     const rest = raw.slice(prefix.length + 1);
-    if (!COLOR_TOKEN.test(rest))
-      continue;
-    const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
-    if (scaleName && NON_COLOR_SCALE_NAMES.has(scaleName))
+    if (!isColorScaleToken(rest))
       continue;
     found = raw;
   }
   return found;
+}
+function lastPlaceholderColorToken(className) {
+  let found = null;
+  for (const raw of className.split(/\s+/).filter(Boolean)) {
+    const segments = raw.split(":");
+    if (segments.length !== 2 || segments[0] !== "placeholder")
+      continue;
+    const base = segments[1];
+    if (!base.startsWith("text-"))
+      continue;
+    const rest = base.slice("text-".length);
+    if (!isColorScaleToken(rest))
+      continue;
+    found = raw;
+  }
+  return found;
+}
+var PLACEHOLDER_CAPABLE_TAGS = /* @__PURE__ */ new Set(["input", "textarea"]);
+function isPlaceholderCapable(openingElement) {
+  return t2.isJSXIdentifier(openingElement.name) && PLACEHOLDER_CAPABLE_TAGS.has(openingElement.name.name);
+}
+function resolveBg(path) {
+  const className = getStaticClassName(path.node.openingElement.attributes);
+  const ownBg = className ? lastColorToken(className, "bg") : null;
+  if (ownBg)
+    return { bg: ownBg, source: "self" };
+  const parentNode = path.parentPath?.node;
+  if (parentNode && t2.isJSXElement(parentNode)) {
+    const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
+    const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
+    if (parentBg)
+      return { bg: parentBg, source: "parent" };
+  }
+  return null;
 }
 function extractChecks(code, filePath) {
   const ast = parseJSX(code, filePath);
@@ -49200,21 +49237,18 @@ function extractChecks(code, filePath) {
       if (!className)
         return;
       const textClass = lastColorToken(className, "text");
-      if (!textClass)
+      const placeholderClass = isPlaceholderCapable(path.node.openingElement) ? lastPlaceholderColorToken(className) : null;
+      if (!textClass && !placeholderClass)
         return;
       const line = path.node.openingElement.loc?.start.line ?? 0;
-      const ownBg = lastColorToken(className, "bg");
-      if (ownBg) {
-        checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: ownBg, bgSource: "self" });
+      const bg = resolveBg(path);
+      if (!bg)
         return;
+      if (textClass) {
+        checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: bg.bg, bgSource: bg.source });
       }
-      const parentNode = path.parentPath?.node;
-      if (parentNode && t2.isJSXElement(parentNode)) {
-        const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
-        const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
-        if (parentBg) {
-          checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: parentBg, bgSource: "parent" });
-        }
+      if (placeholderClass) {
+        checks.push({ file: filePath, line, textColorClass: placeholderClass, bgColorClass: bg.bg, bgSource: bg.source });
       }
     }
   });
@@ -49570,7 +49604,7 @@ var semanticColors = {
 
 // ../tailwind-a11y/dist/rules/checkContrast.js
 function resolveColorValue(utilityClass, palette = defaultPalette) {
-  const match = /^(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
+  const match = /^(?:placeholder:)?(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
   if (!match)
     return null;
   const token = match[1];
@@ -49636,7 +49670,7 @@ function checkContrast(checks, palette = defaultPalette) {
   }
   return violations;
 }
-var TEXT_SCALE_SHADE_RE = /^text-([a-z]+)-(\d+)$/;
+var TEXT_SCALE_SHADE_RE = /^(?:placeholder:)?text-([a-z]+)-(\d+)$/;
 function suggestContrastFix(textClass, bgClass, required, palette = defaultPalette) {
   const { base, alpha } = splitOpacityModifier(textClass);
   if (alpha === 0)
@@ -49645,6 +49679,7 @@ function suggestContrastFix(textClass, bgClass, required, palette = defaultPalet
   if (!match)
     return null;
   const [, scale, shade] = match;
+  const isPlaceholder = base.startsWith("placeholder:");
   const shades = palette[scale];
   if (!shades?.[shade])
     return null;
@@ -49661,7 +49696,8 @@ function suggestContrastFix(textClass, bgClass, required, palette = defaultPalet
     const effectiveRgb = alpha < 1 ? applyAlpha(rgb, alpha, bgRgb) : rgb;
     const ratio = contrastRatio(effectiveRgb, bgRgb);
     if (ratio >= required) {
-      const suggestedClass = alpha < 1 ? `text-${scale}-${candidate}/${Math.round(alpha * 100)}` : `text-${scale}-${candidate}`;
+      const suggestedBase = alpha < 1 ? `text-${scale}-${candidate}/${Math.round(alpha * 100)}` : `text-${scale}-${candidate}`;
+      const suggestedClass = isPlaceholder ? `placeholder:${suggestedBase}` : suggestedBase;
       return { textClass: suggestedClass, ratio };
     }
   }

--- a/packages/github-action-tailwind-a11y/package.json
+++ b/packages/github-action-tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-tailwind-a11y",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "GitHub Action that reports WCAG accessibility violations in Tailwind CSS class combinations as inline PR annotations.",
   "private": true,
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.14.1",
+    "tailwind-a11y": "^0.15.0",
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/tailwind-a11y/CLAUDE.md
+++ b/packages/tailwind-a11y/CLAUDE.md
@@ -41,6 +41,27 @@ Tailwind-class-level sizing or focus-style analysis).
   where `Card` sets `bg-white` internally). That's a whole-program,
   type-aware analysis problem — explicitly out of scope. Known limitation,
   not a bug to fix.
+- **Contrast also checks `placeholder:text-*` (WCAG 1.4.3) on `<input>`/
+  `<textarea>` — a genuinely independent candidate from the element's own
+  resting text color, not a variant of it.** `extractClasses.ts`'s
+  `lastPlaceholderColorToken()` recognizes only the exact two-segment shape
+  `placeholder:text-*` (`raw.split(":")` length exactly 2) — a nested shape
+  like `dark:placeholder:text-gray-500` is deliberately NOT recognized, the
+  only choice consistent with how `lastColorToken` already treats every
+  other variant-scoped color candidate in this file (skip outright rather
+  than guess which persistent condition is active). Tag-scoped to
+  `input`/`textarea` (a small local set, not `isInteractiveElement()`,
+  which also matches `button`/`a`/`select` — none of which can render
+  `::placeholder` in any browser); a `placeholder:text-*` class on any other
+  tag is not "maybe irrelevant," it is dead CSS guaranteed never to render,
+  so this is the one contrast candidate in this file that's tag-scoped at
+  all. Reuses `ContrastCheck`/`ContrastViolation` unchanged — no new field:
+  `lastPlaceholderColorToken` returns the full raw string *including* the
+  `placeholder:` prefix (e.g. `"placeholder:text-gray-300"`), and
+  `checkContrast.ts`'s `resolveColorValue`/`TEXT_SCALE_SHADE_RE` tolerate
+  that prefix directly, so every message/skip-reason/suggestion already
+  reads correctly with zero consumer changes across any of the four
+  adapters.
 - **Static `className` string literals only.** Ternaries, `clsx`/`cva`
   composition, and computed class names are not resolved. Skip them silently
   rather than guessing.

--- a/packages/tailwind-a11y/README.md
+++ b/packages/tailwind-a11y/README.md
@@ -53,7 +53,7 @@ Exits `1` on violations — safe to use as a CI gate.
 
 | Check | WCAG | Detects |
 |---|---|---|
-| Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent, including a text-side opacity modifier (`text-gray-400/50`) composited against the background; suggests the nearest passing shade |
+| Contrast | 1.4.3 (AA) | `text-*`/`bg-*` pairs below 4.5:1, same-element or direct-parent, including a text-side opacity modifier (`text-gray-400/50`) composited against the background; also checks `placeholder:text-*` on `<input>`/`<textarea>`; suggests the nearest passing shade |
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `--strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `--strict` (2.4.13, AAA) |

--- a/packages/tailwind-a11y/package.json
+++ b/packages/tailwind-a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-a11y",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Static analysis CLI that catches WCAG accessibility violations — color contrast, touch target size, and focus indicator removal/contrast — in Tailwind CSS class combinations before they ship.",
   "type": "module",
   "bin": {

--- a/packages/tailwind-a11y/src/parser/extractClasses.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.test.ts
@@ -131,4 +131,66 @@ describe("extractChecks", () => {
       { file: "fake.tsx", line: 1, textColorClass: "text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
     ]);
   });
+
+  describe("placeholder:text-* (WCAG 1.4.3 on ::placeholder)", () => {
+    it.each(["input", "textarea"])("catches a placeholder color on a same-element %s", (tag) => {
+      const code = `const C = () => <${tag} className="bg-white placeholder:text-gray-300" />;`;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toEqual([
+        { file: "fake.tsx", line: 1, textColorClass: "placeholder:text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+      ]);
+    });
+
+    it("produces two independent checks when both a resting text color and a placeholder color are present", () => {
+      const code = `const C = () => <input className="bg-white text-gray-300 placeholder:text-gray-200" />;`;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toHaveLength(2);
+      expect(checks).toEqual(
+        expect.arrayContaining([
+          { file: "fake.tsx", line: 1, textColorClass: "text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+          { file: "fake.tsx", line: 1, textColorClass: "placeholder:text-gray-200", bgColorClass: "bg-white", bgSource: "self" },
+        ])
+      );
+    });
+
+    it("last-token-wins within the placeholder candidacy", () => {
+      const code = `const C = () => <input className="bg-white placeholder:text-gray-300 placeholder:text-gray-100" />;`;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toEqual([
+        { file: "fake.tsx", line: 1, textColorClass: "placeholder:text-gray-100", bgColorClass: "bg-white", bgSource: "self" },
+      ]);
+    });
+
+    it("resolves the placeholder candidate via the immediate parent's background, same as resting text", () => {
+      const code = `
+        const C = () => (
+          <div className="bg-white">
+            <input className="placeholder:text-gray-400" />
+          </div>
+        );
+      `;
+      const checks = extractChecks(code, "fake.tsx");
+      expect(checks).toHaveLength(1);
+      expect(checks[0]).toMatchObject({
+        textColorClass: "placeholder:text-gray-400",
+        bgColorClass: "bg-white",
+        bgSource: "parent",
+      });
+    });
+
+    it("does not recognize a nested variant stacked with placeholder: (regression, deliberate v1 scope cut)", () => {
+      const code = `const C = () => <input className="bg-white dark:placeholder:text-gray-500" />;`;
+      expect(extractChecks(code, "fake.tsx")).toEqual([]);
+    });
+
+    it("does not recognize placeholder:text-* on a tag that can never render ::placeholder", () => {
+      const code = `const C = () => <div className="bg-white placeholder:text-gray-300" />;`;
+      expect(extractChecks(code, "fake.tsx")).toEqual([]);
+    });
+
+    it("ignores a non-color decoy on the placeholder path", () => {
+      const code = `const C = () => <input className="bg-white placeholder:text-lg" />;`;
+      expect(extractChecks(code, "fake.tsx")).toEqual([]);
+    });
+  });
 });

--- a/packages/tailwind-a11y/src/parser/extractClasses.ts
+++ b/packages/tailwind-a11y/src/parser/extractClasses.ts
@@ -1,3 +1,4 @@
+import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 import { getStaticClassName, parseJSX, traverse } from "./babelInterop.js";
 
@@ -35,6 +36,16 @@ export const COLOR_TOKEN =
 // bg-red-500 and would otherwise mask it via last-token-wins.
 const NON_COLOR_SCALE_NAMES = new Set(["opacity", "linear", "conic"]);
 
+// One definition, not two hand-mirrored copies (lastColorToken and
+// lastPlaceholderColorToken both need this exact test) -- the same "one
+// definition, not a second copy that could drift" reasoning already applied
+// to COLOR_TOKEN itself.
+function isColorScaleToken(rest: string): boolean {
+  if (!COLOR_TOKEN.test(rest)) return false;
+  const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
+  return !(scaleName && NON_COLOR_SCALE_NAMES.has(scaleName));
+}
+
 export function lastColorToken(className: string, prefix: "text" | "bg"): string | null {
   let found: string | null = null;
   for (const raw of className.split(/\s+/).filter(Boolean)) {
@@ -52,12 +63,72 @@ export function lastColorToken(className: string, prefix: "text" | "bg"): string
     if (raw.includes(":")) continue;
     if (!raw.startsWith(`${prefix}-`)) continue;
     const rest = raw.slice(prefix.length + 1);
-    if (!COLOR_TOKEN.test(rest)) continue;
-    const scaleName = /^([a-z]+)-\d/.exec(rest)?.[1];
-    if (scaleName && NON_COLOR_SCALE_NAMES.has(scaleName)) continue;
+    if (!isColorScaleToken(rest)) continue;
     found = raw;
   }
   return found;
+}
+
+// placeholder:text-* targets the ::placeholder pseudo-element -- a
+// genuinely different rendered text than the element's own resting text
+// color, so it's checked as an independent candidate, not folded into
+// lastColorToken. Deliberately the exact two-segment shape only
+// (raw.split(":") === ["placeholder", "text-..."]) -- a nested shape like
+// dark:placeholder:text-gray-500 is NOT recognized. This isn't a narrower-
+// for-now cut, it's the only choice consistent with how lastColorToken
+// already treats every other variant-scoped color candidate in this same
+// file: skip outright rather than guess which persistent condition is
+// active. Returns the full raw string including the "placeholder:" prefix
+// -- checkContrast.ts's resolveColorValue/suggestContrastFix tolerate the
+// prefix directly, so every downstream message/skip-reason/suggestion
+// already reads correctly with zero further changes.
+function lastPlaceholderColorToken(className: string): string | null {
+  let found: string | null = null;
+  for (const raw of className.split(/\s+/).filter(Boolean)) {
+    const segments = raw.split(":");
+    if (segments.length !== 2 || segments[0] !== "placeholder") continue;
+    const base = segments[1];
+    if (!base.startsWith("text-")) continue;
+    const rest = base.slice("text-".length);
+    if (!isColorScaleToken(rest)) continue;
+    found = raw;
+  }
+  return found;
+}
+
+// ::placeholder only exists on <input>/<textarea> in any browser -- a
+// placeholder:text-* class on any other tag is not "maybe irrelevant," it
+// is dead CSS, guaranteed never to render. Unlike reduced-motion's
+// deliberate "not scoped to isInteractiveElement()" choice (a hover-
+// animated <div> genuinely animates), tag-scoping here prevents a
+// guaranteed false positive rather than narrowing a genuine one. A small
+// local set, not a reuse of isInteractiveElement() -- that helper also
+// matches button/a/select and any onClick-bearing element, none of which
+// can render a placeholder.
+const PLACEHOLDER_CAPABLE_TAGS = new Set(["input", "textarea"]);
+
+function isPlaceholderCapable(openingElement: t.JSXOpeningElement): boolean {
+  return (
+    t.isJSXIdentifier(openingElement.name) && PLACEHOLDER_CAPABLE_TAGS.has(openingElement.name.name)
+  );
+}
+
+// Resolves an element's background exactly once (self, else immediate JSX
+// parent — see extractChecks' own scope note) so both the resting-text and
+// placeholder candidates share one bg/bgSource pair rather than each
+// re-walking the parent chain independently.
+function resolveBg(path: NodePath<t.JSXElement>): { bg: string; source: "self" | "parent" } | null {
+  const className = getStaticClassName(path.node.openingElement.attributes);
+  const ownBg = className ? lastColorToken(className, "bg") : null;
+  if (ownBg) return { bg: ownBg, source: "self" };
+
+  const parentNode = path.parentPath?.node;
+  if (parentNode && t.isJSXElement(parentNode)) {
+    const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
+    const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
+    if (parentBg) return { bg: parentBg, source: "parent" };
+  }
+  return null;
 }
 
 export function extractChecks(code: string, filePath: string): ContrastCheck[] {
@@ -72,25 +143,23 @@ export function extractChecks(code: string, filePath: string): ContrastCheck[] {
       if (!className) return;
 
       const textClass = lastColorToken(className, "text");
-      if (!textClass) return;
+      const placeholderClass = isPlaceholderCapable(path.node.openingElement)
+        ? lastPlaceholderColorToken(className)
+        : null;
+      if (!textClass && !placeholderClass) return;
 
       const line = path.node.openingElement.loc?.start.line ?? 0;
 
-      const ownBg = lastColorToken(className, "bg");
-      if (ownBg) {
-        checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: ownBg, bgSource: "self" });
-        return;
-      }
-
       // Only the immediate JSX parent is considered — no deeper ancestor
       // walk and no cross-component resolution (see CLAUDE.md scope).
-      const parentNode = path.parentPath?.node;
-      if (parentNode && t.isJSXElement(parentNode)) {
-        const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
-        const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
-        if (parentBg) {
-          checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: parentBg, bgSource: "parent" });
-        }
+      const bg = resolveBg(path);
+      if (!bg) return;
+
+      if (textClass) {
+        checks.push({ file: filePath, line, textColorClass: textClass, bgColorClass: bg.bg, bgSource: bg.source });
+      }
+      if (placeholderClass) {
+        checks.push({ file: filePath, line, textColorClass: placeholderClass, bgColorClass: bg.bg, bgSource: bg.source });
       }
     },
   });
@@ -122,37 +191,38 @@ export function extractContrastSkips(code: string, filePath: string): ContrastSk
       if (!className) return;
 
       const textClass = lastColorToken(className, "text");
-      if (!textClass) return;
+      const placeholderClass = isPlaceholderCapable(path.node.openingElement)
+        ? lastPlaceholderColorToken(className)
+        : null;
+      if (!textClass && !placeholderClass) return;
 
-      const ownBg = lastColorToken(className, "bg");
-      if (ownBg) return; // extractChecks already covers this case
+      if (resolveBg(path)) return; // extractChecks already covers this case, for either candidate
 
       const line = path.node.openingElement.loc?.start.line ?? 0;
       const parentNode = path.parentPath?.node;
-
-      if (parentNode && t.isJSXElement(parentNode)) {
-        const parentClassName = getStaticClassName(parentNode.openingElement.attributes);
-        const parentBg = parentClassName ? lastColorToken(parentClassName, "bg") : null;
-        if (parentBg) return; // extractChecks already covers this case
-
-        const parentTag = t.isJSXIdentifier(parentNode.openingElement.name)
+      const parentTag =
+        parentNode && t.isJSXElement(parentNode) && t.isJSXIdentifier(parentNode.openingElement.name)
           ? parentNode.openingElement.name.name
           : null;
+
+      const reportSkip = (candidateClass: string) => {
         if (parentTag && /^[A-Z]/.test(parentTag)) {
           skips.push({
             file: filePath,
             line,
-            reason: `${textClass} — background may be set inside <${parentTag}>, which this tool doesn't inspect across component boundaries`,
+            reason: `${candidateClass} — background may be set inside <${parentTag}>, which this tool doesn't inspect across component boundaries`,
           });
           return;
         }
-      }
+        skips.push({
+          file: filePath,
+          line,
+          reason: `${candidateClass} — no background utility found on this element or its immediate parent`,
+        });
+      };
 
-      skips.push({
-        file: filePath,
-        line,
-        reason: `${textClass} — no background utility found on this element or its immediate parent`,
-      });
+      if (textClass) reportSkip(textClass);
+      if (placeholderClass) reportSkip(placeholderClass);
     },
   });
 

--- a/packages/tailwind-a11y/src/parser/extractContrastSkips.test.ts
+++ b/packages/tailwind-a11y/src/parser/extractContrastSkips.test.ts
@@ -55,4 +55,64 @@ describe("extractContrastSkips", () => {
     expect(() => extractContrastSkips(code, "fake.tsx")).not.toThrow();
     expect(extractContrastSkips(code, "fake.tsx")).toEqual([]);
   });
+
+  describe("placeholder:text-*", () => {
+    it("flags the component-boundary case for a placeholder candidate", () => {
+      const code = `
+        const C = () => (
+          <Card>
+            <input className="placeholder:text-gray-300" />
+          </Card>
+        );
+      `;
+      const skips = extractContrastSkips(code, "fake.tsx");
+      expect(skips).toHaveLength(1);
+      expect(skips[0].reason).toContain("<Card>");
+      expect(skips[0].reason).toContain("placeholder:text-gray-300");
+    });
+
+    it("flags when there is no background anywhere for a placeholder candidate", () => {
+      const code = `
+        const C = () => (
+          <section>
+            <input className="placeholder:text-gray-300" />
+          </section>
+        );
+      `;
+      const skips = extractContrastSkips(code, "fake.tsx");
+      expect(skips).toHaveLength(1);
+      expect(skips[0].reason).toContain("no background utility found");
+      expect(skips[0].reason).toContain("placeholder:text-gray-300");
+    });
+
+    it("reports two independent skips when both resting text and placeholder candidates lack a background", () => {
+      const code = `
+        const C = () => (
+          <section>
+            <input className="text-gray-300 placeholder:text-gray-200" />
+          </section>
+        );
+      `;
+      const skips = extractContrastSkips(code, "fake.tsx");
+      expect(skips).toHaveLength(2);
+      expect(skips.map((s) => s.reason).join("\n")).toContain("text-gray-300");
+      expect(skips.map((s) => s.reason).join("\n")).toContain("placeholder:text-gray-200");
+    });
+
+    it("does not flag a placeholder candidate extractChecks already resolves", () => {
+      const code = `const C = () => <input className="bg-white placeholder:text-gray-300" />;`;
+      expect(extractContrastSkips(code, "fake.tsx")).toEqual([]);
+    });
+
+    it("does not flag a placeholder-shaped class on a tag that can never render ::placeholder", () => {
+      const code = `
+        const C = () => (
+          <section>
+            <div className="placeholder:text-gray-300" />
+          </section>
+        );
+      `;
+      expect(extractContrastSkips(code, "fake.tsx")).toEqual([]);
+    });
+  });
 });

--- a/packages/tailwind-a11y/src/rules/checkContrast.test.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.test.ts
@@ -89,6 +89,46 @@ describe("checkContrast", () => {
   });
 });
 
+describe("checkContrast on a placeholder:text-* candidate", () => {
+  it("flags a failing placeholder color, keeping the placeholder: prefix in textClass", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "placeholder:text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ textClass: "placeholder:text-gray-300", bgClass: "bg-white" });
+  });
+
+  it("carries a suggestion that preserves the placeholder: prefix (copy-pasteable)", () => {
+    const [v] = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "placeholder:text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(v.suggestion).toMatch(/^placeholder:text-gray-\d+$/);
+    expect(v.suggestedRatio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("resolves a placeholder color combined with a text-side opacity modifier", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "placeholder:text-gray-900/30", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("produces two independent violations when both a resting text and placeholder candidate fail", () => {
+    const violations = checkContrast([
+      { file: "f.tsx", line: 1, textColorClass: "text-gray-300", bgColorClass: "bg-white", bgSource: "self" },
+      { file: "f.tsx", line: 1, textColorClass: "placeholder:text-gray-200", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.textClass).sort()).toEqual(["placeholder:text-gray-200", "text-gray-300"]);
+  });
+
+  it("composes end-to-end with extractChecks for an <input> with both candidates", () => {
+    const code = `const C = () => <input className="bg-white text-gray-300 placeholder:text-gray-200" />;`;
+    const violations = checkContrast(extractChecks(code, "fake.tsx"));
+    expect(violations).toHaveLength(2);
+  });
+});
+
 describe("checkContrast with a text-side opacity modifier", () => {
   it("flags a previously-invisible violation: dark text at low opacity reads as light", () => {
     // text-gray-900 alone passes easily against white; at 30% opacity it
@@ -274,6 +314,14 @@ describe("checkContrastValueSkips", () => {
     expect(skips).toHaveLength(1);
     expect(skips[0].reason).toContain("bg-brand-50");
   });
+
+  it("names the full placeholder:-prefixed class in an unresolved-color skip reason", () => {
+    const skips = checkContrastValueSkips([
+      { file: "f.tsx", line: 1, textColorClass: "placeholder:text-brand-500", bgColorClass: "bg-white", bgSource: "self" },
+    ]);
+    expect(skips).toHaveLength(1);
+    expect(skips[0].reason).toContain("placeholder:text-brand-500");
+  });
 });
 
 describe("suggestContrastFix", () => {
@@ -346,6 +394,17 @@ describe("suggestContrastFix", () => {
     expect(fix).not.toBeNull();
     expect(fix?.textClass).not.toBe("text-gray-400");
     expect(fix?.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("re-prepends the placeholder: prefix onto the suggested class (copy-pasteable, not a bare text-* class)", () => {
+    const fix = suggestContrastFix("placeholder:text-gray-400", "bg-white", 4.5);
+    expect(fix?.textClass).toBe("placeholder:text-gray-500");
+    expect(fix?.ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("preserves both the placeholder: prefix and the opacity modifier together", () => {
+    const fix = suggestContrastFix("placeholder:text-gray-400/80", "bg-white", 4.5);
+    expect(fix?.textClass).toBe("placeholder:text-gray-600/80");
   });
 
   it("finds a fix within a custom-theme scale that the default palette doesn't have", () => {

--- a/packages/tailwind-a11y/src/rules/checkContrast.ts
+++ b/packages/tailwind-a11y/src/rules/checkContrast.ts
@@ -20,8 +20,14 @@ export interface ContrastViolation {
 export function resolveColorValue(utilityClass: string, palette: Palette = defaultPalette): string | null {
   // outline/ring are here for checkFocusIndicator.ts's non-text-contrast
   // check (WCAG 1.4.11/2.4.13) -- same palette/arbitrary-hex/semantic-color
-  // resolution as text/bg, just a different utility prefix.
-  const match = /^(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
+  // resolution as text/bg, just a different utility prefix. The optional
+  // leading "placeholder:" tolerates extractClasses.ts's
+  // lastPlaceholderColorToken, which deliberately keeps that prefix on the
+  // class string it returns -- harmless to accept on all four prefixes
+  // here since extraction only ever produces "placeholder:text-*", never
+  // "placeholder:bg-*"/etc., and checkFocusIndicator.ts's own call sites
+  // can never pass a placeholder:-prefixed string into this function.
+  const match = /^(?:placeholder:)?(?:text|bg|outline|ring)-(.+)$/.exec(utilityClass);
   if (!match) return null;
   const token = match[1];
 
@@ -108,7 +114,10 @@ export interface ContrastFix {
   ratio: number;
 }
 
-const TEXT_SCALE_SHADE_RE = /^text-([a-z]+)-(\d+)$/;
+// Optional leading "placeholder:" tolerated for the same reason as
+// resolveColorValue's regex above -- suggestContrastFix re-prepends it to
+// the suggested class below so the suggestion stays copy-pasteable.
+const TEXT_SCALE_SHADE_RE = /^(?:placeholder:)?text-([a-z]+)-(\d+)$/;
 
 // Only the text shade moves — bg and any opacity modifier on the text class
 // stay fixed, since text color is the more commonly adjustable side in
@@ -132,6 +141,7 @@ export function suggestContrastFix(
   if (!match) return null; // text-white, text-[#eee] — no suggestion
 
   const [, scale, shade] = match;
+  const isPlaceholder = base.startsWith("placeholder:");
   const shades = palette[scale];
   if (!shades?.[shade]) return null; // custom scale, or a decoy like text-opacity-50
 
@@ -153,7 +163,8 @@ export function suggestContrastFix(
     const effectiveRgb = alpha < 1 ? applyAlpha(rgb, alpha, bgRgb) : rgb;
     const ratio = contrastRatio(effectiveRgb, bgRgb);
     if (ratio >= required) {
-      const suggestedClass = alpha < 1 ? `text-${scale}-${candidate}/${Math.round(alpha * 100)}` : `text-${scale}-${candidate}`;
+      const suggestedBase = alpha < 1 ? `text-${scale}-${candidate}/${Math.round(alpha * 100)}` : `text-${scale}-${candidate}`;
+      const suggestedClass = isPlaceholder ? `placeholder:${suggestedBase}` : suggestedBase;
       return { textClass: suggestedClass, ratio };
     }
   }

--- a/packages/vscode-tailwind-a11y/README.md
+++ b/packages/vscode-tailwind-a11y/README.md
@@ -11,7 +11,7 @@ reimplemented here.
 
 | Check | WCAG | Detects |
 |---|---|---|
-| Contrast | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs — with a suggested nearby shade |
+| Contrast | 1.4.3 (AA) | Low-contrast `text-*`/`bg-*` pairs, plus `placeholder:text-*` on `<input>`/`<textarea>` — with a suggested nearby shade |
 | Touch target | 2.5.8 (AA) | Interactive elements under 24×24px — or 44×44px with `tailwind-a11y.strict` (2.5.5, AAA) |
 | Focus indicator | 2.4.7 (AA) | `focus:outline-none` with no visible replacement |
 | Focus indicator contrast | 1.4.11 (AA) | A present `outline-*`/`ring-*` focus indicator below 3:1 contrast — or also below the 2px minimum thickness with `tailwind-a11y.strict` (2.4.13, AAA) |

--- a/packages/vscode-tailwind-a11y/package.json
+++ b/packages/vscode-tailwind-a11y/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tailwind-a11y",
   "displayName": "Tailwind a11y",
   "description": "Static accessibility analysis for Tailwind CSS projects 🩵",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "icon": "icon.png",
   "publisher": "HaeunKim",
@@ -66,7 +66,7 @@
     "publish:vsix": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "tailwind-a11y": "^0.14.1"
+    "tailwind-a11y": "^0.15.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## What

Adds a new WCAG 1.4.3 (AA) detection surface: contrast checking for `placeholder:text-*` classes on `<input>`/`<textarea>`, which style the `::placeholder` pseudo-element independently of the element's own resting text color.

## Why

`extractClasses.ts`'s `lastColorToken()` skips any variant-scoped class outright (`if (raw.includes(":")) continue;`), so `placeholder:text-*` was never even considered a candidate — real, rendered placeholder text went completely unchecked. This closes that gap as an independent axis alongside the existing resting-text check, so a single `<input>` can fail on its resting text color, its placeholder color, or both at once. The new extractor function matches only the exact two-segment `placeholder:text-*` shape and deliberately does not recognize a nested variant like `dark:placeholder:text-gray-500` — the only choice consistent with how `lastColorToken` already treats every other variant-scoped color candidate in the same file: skip outright rather than guess which persistent condition is active. Detection is scoped to `<input>`/`<textarea>` specifically, since `::placeholder` cannot render on any other element in any browser — a `placeholder:text-*` class elsewhere is dead CSS, so this avoids a guaranteed false positive rather than narrowing a genuine one. The extractor keeps the `placeholder:` prefix on the class string it returns, and `checkContrast.ts`'s existing resolution and suggestion logic were made to tolerate that prefix directly — so every message, skip reason, and fix suggestion across all four adapters already reads correctly (and stays copy-pasteable) with zero consumer-side changes.

## Versions

`tailwind-a11y`, `eslint-plugin-tailwind-a11y`, and `github-action-tailwind-a11y` go from 0.14.1 to 0.15.0; `vscode-tailwind-a11y` goes from 0.15.1 to 0.16.0. The GitHub Action's committed `dist/index.js` bundle is rebuilt and included.

## Test plan

`npm test --workspaces` passes across all four packages (513 tests). Verified directly against the built CLI: `<input className="bg-white placeholder:text-gray-300" />` now flags with a copy-pasteable `placeholder:text-gray-500` suggestion where it previously produced nothing; the identical class on a `<div>` does not flag (tag scope); `dark:placeholder:text-gray-500` does not flag (deliberate scope cut). New coverage spans same-element and parent-background resolution for the placeholder candidate, two independent violations on one element, opacity-modifier composition, `--verbose` skip-reason wording, and confirms the widened internal regexes can't reach `checkFocusIndicator.ts`'s unrelated call sites.